### PR TITLE
Revert "Use Git Bash as Yarn Shell in Windows system setup"

### DIFF
--- a/windows.md
+++ b/windows.md
@@ -15,24 +15,12 @@ Before you start, please make sure that you're running Windows 8.1 or Windows 10
    <img src="./windows-2-chocolatey-installed.png"><br><br>
 5. Close PowerShell and open it again as administrator (like in step 1)<br><br>
 6. Copy the following text and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
-
    ```bash
    choco install git nodejs yarn vscode hyper zoom slack postman -y
    ```
-
    This uses Chocolatey to install Git, Node.js, Yarn, Visual Studio Code, Hyper, Zoom, Slack and Postman.<br><br>
    **Note:** If you are using Windows 7, you may have encountered a problem with installing Node.js because [the latest versions no longer support Windows 7](https://github.com/nodejs/node/issues/33000). To get around this, run this separately: `choco install nodejs -y --version 13.6.0`<br><br>
-
-7. Copy each line in the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.<br><br>
-
-   ```bash
-   yarn config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"
-   yarn config set shell "C:\\Program Files\\Git\\bin\\bash.exe"
-   ```
-
-   This configures Yarn to run scripts in a way that's more compatible with other systems.<br><br>
-
-8. Copy each line in the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.
+7. Copy each line in the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.
 
    ```bash
    choco install python visualcpp-build-tools -y
@@ -41,7 +29,7 @@ Before you start, please make sure that you're running Windows 8.1 or Windows 10
 
    This uses Chocolatey to install some Windows build tools to help with installing some Node.js native modules.
 
-9. Copy each line in the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.<br><br>
+8. Copy each line in the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.<br><br>
 
    ```bash
    code --install-extension Cardinal90.multi-cursor-case-preserve
@@ -59,18 +47,18 @@ Before you start, please make sure that you're running Windows 8.1 or Windows 10
 
    This installs some VS Code extensions we will need.<br><br>
 
-10. We recommend installing and using Chrome so that you have the same Devtools as others.<br><br>
-    If you don't have Chrome installed yet, you can install it with Homebrew. To do this, copy the following text and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
-    ```bash
-    choco install chrome -y
-    ```
-    This uses Chocolatey to install Chrome.<br><br>
-11. Install the following Chrome Extensions:
+9. We recommend installing and using Chrome so that you have the same Devtools as others.<br><br>
+   If you don't have Chrome installed yet, you can install it with Homebrew. To do this, copy the following text and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
+   ```bash
+   choco install chrome -y
+   ```
+   This uses Chocolatey to install Chrome.<br><br>
+10. Install the following Chrome Extensions:
     - [React Developer tools Chrome Extension](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en)
     - [Refined GitHub Chrome Extension](https://chrome.google.com/webstore/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf?hl=en)
     - [Web Vitals Chrome Extension](https://chrome.google.com/webstore/detail/web-vitals/ahfhijdlegdabablpippeagghigmibma?hl=en)
-12. Close PowerShell and open it again as administrator (like in step 1)<br><br>
-13. Copy the following text and right-click in the PowerShell window to paste the text. Hit enter.<br><br>
+11. Close PowerShell and open it again as administrator (like in step 1)<br><br>
+12. Copy the following text and right-click in the PowerShell window to paste the text. Hit enter.<br><br>
 
     ```bash
     CI=true npx create-react-app --help
@@ -79,12 +67,12 @@ Before you start, please make sure that you're running Windows 8.1 or Windows 10
     This will prepare a program that we will use in the course. This will take a while and then respond with a message that some modules have been installed, similar to this:<br><br>
     <img src="./general-1-cra-installed.png"><br><br>
 
-14. Copy the following text and right-click in the PowerShell window to paste the text. Hit enter.<br><br>
+13. Copy the following text and right-click in the PowerShell window to paste the text. Hit enter.<br><br>
     ```bash
     yarn global add @upleveled/preflight
     ```
     This will prepare a program that we will use in the course.<br><br>
-15. Next we will configure VS Code.<br><br>
+14. Next we will configure VS Code.<br><br>
     Open VS Code and then press the keys <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>P</kbd>. Type in "Settings" and select the item that says `Preferences: Open Settings (JSON)`:<br><br>
     <img src="./general-2-vscode-settings.png"><br><br>
     Once the settings file is open, we will want to add the settings below.<br><br>
@@ -144,7 +132,7 @@ Before you start, please make sure that you're running Windows 8.1 or Windows 10
     If you have any of these warnings, we should fix them. For each one of these lines with the warnings on them, delete the full line, including the comma at the end. We usually like to select from the start of the first `"` to just before the next `"` on the next line:<br><br>
     <img src="./general-5-vscode-settings-fix-warnings.png"><br><br>
 
-16. Now we will configure Hyper.<br><br>
+15. Now we will configure Hyper.<br><br>
     Open Hyper and then select Edit -> Preferences, which will open a text file in an editor:<br><br>
     <img src="./windows-3-hyper-preferences.png"><br><br>
     In this file, we will do three things:
@@ -154,7 +142,7 @@ Before you start, please make sure that you're running Windows 8.1 or Windows 10
 
     Then save the file and close and restart Hyper.
 
-17. <a name="postgresql"></a>We will now install PostgreSQL. Search for Hyper in the start menu, then right click on it and choose "Run as Administrator".
+16. <a name="postgresql"></a>We will now install PostgreSQL. Search for Hyper in the start menu, then right click on it and choose "Run as Administrator".
 
     Copy the following text, paste it in Hyper and hit return.
 
@@ -255,7 +243,7 @@ Before you start, please make sure that you're running Windows 8.1 or Windows 10
 
     <img src="./macos-5.6-psql.png"><br><br>
 
-18. <a name="docker"></a>We will now install Docker.
+17. <a name="docker"></a>We will now install Docker.
 
     **Option A - Windows 10 Pro:**
 
@@ -285,7 +273,7 @@ Before you start, please make sure that you're running Windows 8.1 or Windows 10
     4. Open the start menu and search for "Ubuntu". Start it - it should ask you to create a user with a password. This will be your user to log in to your Ubuntu Linux Subsystem - note down the username and password somewhere secure to make sure you do not forget it.
     5. Open the start menu and search for "Docker Desktop". Start it and go to the Settings. Under the General tab, you will find an option called "Use WSL 2 based engine". Make sure this is checked.
 
-19. Test if Docker is installed by running the following command on the command line:
+18. Test if Docker is installed by running the following command on the command line:
 
     ```bash
     docker run hello-world
@@ -294,7 +282,7 @@ Before you start, please make sure that you're running Windows 8.1 or Windows 10
     It should print out a welcome message like this:<br><br>
     <img src="macos-6-docker-hello-world.png"><br><br>
 
-20. <a name="expo-react-native"></a>We will now install Expo CLI for React Native. Search for Hyper in the start menu, then right click on it and choose "Run as Administrator".
+19. <a name="expo-react-native"></a>We will now install Expo CLI for React Native. Search for Hyper in the start menu, then right click on it and choose "Run as Administrator".
 
     Copy the following text, paste it in Hyper and hit return.
 
@@ -304,8 +292,8 @@ Before you start, please make sure that you're running Windows 8.1 or Windows 10
 
     On your phone, go to the app store and install Expo on your phone. Create an account and log in.
 
-21. Install the Android Studio Emulator for Expo by following this guide: https://docs.expo.io/workflow/android-studio-emulator/
-22. To verify that Expo is working with Android Studio, first start Android Studio, click on "Configure" and select AVD Manager. Click on the green play button next to one of the devices.
+20. Install the Android Studio Emulator for Expo by following this guide: https://docs.expo.io/workflow/android-studio-emulator/
+21. To verify that Expo is working with Android Studio, first start Android Studio, click on "Configure" and select AVD Manager. Click on the green play button next to one of the devices.
 
     Then copy and run each of these lines separately in Hyper:
 
@@ -320,14 +308,14 @@ Before you start, please make sure that you're running Windows 8.1 or Windows 10
 
     This should run an Expo demo application, which will show you the Expo Developer Tools. In the left panel, select "Run on Android device/emulator". This should open up an Android emulator. It should show the words "Universal React with Expo".
 
-23. If you don't have one yet, create a Google account [here](https://accounts.google.com/signup?hl=en). Send the email address associated with this account to Antje (if you haven't already).
-24. If you don't have one yet, create a GitHub account [here](https://github.com/join). Make sure to set a name.
+22. If you don't have one yet, create a Google account [here](https://accounts.google.com/signup?hl=en). Send the email address associated with this account to Antje (if you haven't already).
+23. If you don't have one yet, create a GitHub account [here](https://github.com/join). Make sure to set a name.
 
     If you already have a GitHub account and you haven't set a name on GitHub yet, go to the [GitHub Profile Settings](https://github.com/settings/profile) and add a name:<br><br>
     <img src="./general-6-github-profile-settings.png"><br><br>
     We will use this name in the next step.<br><br>
 
-25. For this step, we'll need to **edit some of the information in the commands** by adding our own information.<br><br>
+24. For this step, we'll need to **edit some of the information in the commands** by adding our own information.<br><br>
     First of all, we will set our name, which will be the same name as on our GitHub profile:<br><br>
     <img src="./general-7-github-name.png"><br><br>
     Copy your name from your profile, **add it in quotes** in the command (replace `Mona Lisa Octocat`) and run the command:<br><br>
@@ -347,28 +335,28 @@ Before you start, please make sure that you're running Windows 8.1 or Windows 10
     git config --global user.email
     ```
     This prepares `git` so that your work is attributed correctly to you.<br><br>
-26. Copy the following text, paste it in the terminal and hit return.<br><br>
+25. Copy the following text, paste it in the terminal and hit return.<br><br>
     ```bash
     git config --global credential.helper wincred
     ```
     This step will save your GitHub password so that you don't need to enter it every time.<br><br>
-27. Copy the following text, paste it in the terminal and hit return.<br><br>
+26. Copy the following text, paste it in the terminal and hit return.<br><br>
     ```bash
     git config --global init.defaultBranch main
     ```
     This step will change the default Git branch from `master` to `main` (see https://github.com/github/renaming).<br><br>
-28. Copy and run each of these lines separately in Hyper.<br><br>
+27. Copy and run each of these lines separately in Hyper.<br><br>
     ```bash
     git config --global core.autocrlf false
     git config --global core.eol lf
     ```
     This step will improve line breaks compatibility on Windows.
-29. Go back to GitHub, and go to your profile page by clicking on your avatar at the top right and selecting **Your profile**<br><br>
+28. Go back to GitHub, and go to your profile page by clicking on your avatar at the top right and selecting **Your profile**<br><br>
     <img src="./general-8-github-your-profile.png"><br><br>
     Copy the `github.com/...` URL in the address bar of your browser, for use in the next step.
-30. Open the Start menu and start Slack. Log in to the UpLeveled Slack. Send your GitHub profile URL to Antje.
-31. Open the start menu, type "Settings" and open the app (or click on the cog on the left). Select "System" and "About". Under "Device specifications", click the Copy button and paste this to Antje. Under "Windows specifications", click the Copy button and paste this to Antje.
-32. On your phone, go to the app store and install Slack on your phone. Log in to the UpLeveled Slack.
+29. Open the Start menu and start Slack. Log in to the UpLeveled Slack. Send your GitHub profile URL to Antje.
+30. Open the start menu, type "Settings" and open the app (or click on the cog on the left). Select "System" and "About". Under "Device specifications", click the Copy button and paste this to Antje. Under "Windows specifications", click the Copy button and paste this to Antje.
+31. On your phone, go to the app store and install Slack on your phone. Log in to the UpLeveled Slack.
 
 ## Optional Software
 


### PR DESCRIPTION
Reverts upleveled/system-setup#9

This causes strange problems such as:

```
/D/upleveled-softwork/courses/slide-decks (add-web-terminology-deck)
$ yarn mdx-deck state-management/index.mdx
yarn run v1.22.5
$ D:\upleveled-softwork\courses\slide-decks\node_modules\.bin\mdx-deck state-management/index.mdx
/usr/bin/bash: D:upleveled-softworkcoursesslide-decksnode_modules.binmdx-deck: command not found
```