### PR TITLE
Enable Stylelint for scss

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -169,6 +169,7 @@
     "stylelint.validate": [
       "css",
       "less",
+      "scss",
       "postcss",
       "javascript",
       "typescriptreact"

--- a/macos.md
+++ b/macos.md
@@ -141,6 +141,7 @@
     "stylelint.validate": [
       "css",
       "less",
+      "scss",
       "postcss",
       "javascript",
       "typescriptreact"

--- a/windows.md
+++ b/windows.md
@@ -161,6 +161,7 @@ With those compatibility things out of the way, you're ready to start the system
     "stylelint.validate": [
       "css",
       "less",
+      "scss",
       "postcss",
       "javascript",
       "typescriptreact"


### PR DESCRIPTION
Since we're using CSS Modules with Sass (scss) with Next.js 13+ and the app directory, we need to enable Stylelint for these syntaxes