### PR TITLE
Update Homebrew to Chocolatey in Windows guide

### DIFF
--- a/windows.md
+++ b/windows.md
@@ -87,7 +87,7 @@ With those compatibility things out of the way, you're ready to start the system
    This installs some VS Code extensions we will need.<br><br>
 
 10. We recommend installing and using Chrome so that you have the same DevTools as others.<br><br>
-    If you don't have Chrome installed yet, you can install it with Homebrew. To do this, copy the following text and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
+    If you don't have Chrome installed yet, you can install it with Chocolatey. To do this, copy the following text and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
     ```bash
     choco install googlechrome -y
     ```


### PR DESCRIPTION
## Description

This PR corrects a minor typo in our Windows system setup guide, which previously said to use Homebrew. The guide has now been updated to Chocolatey instead.

