### PR TITLE
Switch to pnpm hoisted linker in Expo .npmrc

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -340,7 +340,7 @@
 
 21. To verify that Expo is working with the Android Studio virtual device copy and run each of these lines separately in the terminal:
 
-      <!-- TODO: Remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
+      <!-- TODO: Check if we can remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
 
     ```bash
     cd ~

--- a/linux.md
+++ b/linux.md
@@ -346,6 +346,8 @@
     cd projects
     pnpm create expo-app expo-test --template blank
     cd expo-test
+    echo 'node-linker=hoisted' > ./.npmrc
+    pnpm install --force
     pnpm start --android
     ```
 

--- a/linux.md
+++ b/linux.md
@@ -340,7 +340,7 @@
 
 21. To verify that Expo is working with the Android Studio virtual device copy and run each of these lines separately in the terminal:
 
-      <!-- TODO: Check if we can remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
+    <!-- TODO: Check if we can remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
 
     ```bash
     cd ~

--- a/linux.md
+++ b/linux.md
@@ -340,6 +340,8 @@
 
 21. To verify that Expo is working with the Android Studio virtual device copy and run each of these lines separately in the terminal:
 
+      <!-- TODO: Remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
+
     ```bash
     cd ~
     mkdir -p projects

--- a/macos.md
+++ b/macos.md
@@ -360,7 +360,7 @@
 
 20. To verify that Expo is working with the Android Studio virtual device copy and run each of these lines separately in the terminal:
 
-      <!-- TODO: Check if we can remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
+    <!-- TODO: Check if we can remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
 
     ```bash
     cd ~

--- a/macos.md
+++ b/macos.md
@@ -360,7 +360,7 @@
 
 20. To verify that Expo is working with the Android Studio virtual device copy and run each of these lines separately in the terminal:
 
-      <!-- TODO: Remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
+      <!-- TODO: Check if we can remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
 
     ```bash
     cd ~

--- a/macos.md
+++ b/macos.md
@@ -360,6 +360,8 @@
 
 20. To verify that Expo is working with the Android Studio virtual device copy and run each of these lines separately in the terminal:
 
+      <!-- TODO: Remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
+
     ```bash
     cd ~
     mkdir -p projects

--- a/macos.md
+++ b/macos.md
@@ -366,6 +366,8 @@
     cd projects
     pnpm create expo-app expo-test --template blank
     cd expo-test
+    echo 'node-linker=hoisted' > ./.npmrc
+    pnpm install --force
     pnpm start --android
     ```
 

--- a/windows.md
+++ b/windows.md
@@ -444,6 +444,8 @@ With those compatibility things out of the way, you're ready to start the system
     cd projects
     pnpm create expo-app expo-test --template blank
     cd expo-test
+    echo 'node-linker=hoisted' > ./.npmrc
+    pnpm install --force
     pnpm start --android
     ```
 

--- a/windows.md
+++ b/windows.md
@@ -438,7 +438,7 @@ With those compatibility things out of the way, you're ready to start the system
 
 22. To verify that Expo is working with the Android Studio virtual device copy and run each of these lines separately in Hyper:
 
-      <!-- TODO: Remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
+      <!-- TODO: Check if we can remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
 
     ```bash
     cd ~

--- a/windows.md
+++ b/windows.md
@@ -438,7 +438,7 @@ With those compatibility things out of the way, you're ready to start the system
 
 22. To verify that Expo is working with the Android Studio virtual device copy and run each of these lines separately in Hyper:
 
-      <!-- TODO: Check if we can remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
+    <!-- TODO: Check if we can remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
 
     ```bash
     cd ~

--- a/windows.md
+++ b/windows.md
@@ -438,6 +438,8 @@ With those compatibility things out of the way, you're ready to start the system
 
 22. To verify that Expo is working with the Android Studio virtual device copy and run each of these lines separately in Hyper:
 
+      <!-- TODO: Remove the `echo ...` and `pnpm install ...` steps below when Expo supports RN 0.72 with symlinks https://github.com/upleveled/system-setup/issues/28 -->
+
     ```bash
     cd ~
     mkdir -p projects


### PR DESCRIPTION
Issue:
- https://github.com/facebook/metro/issues/1

## Description

All system setup guides contain a step to set up a project using `create-expo-app` to test if Expo and React Native are set up properly. Metro (the bundler used in React Native) has problems when performing this step with `pnpm`:

```
Error: Unable to resolve module ./node_modules/expo/AppEntry
```

This is caused by duplicate dependencies in nested `node_modules` folders, which pnpm creates to improve performance and reduce disk space usage.

To fix this issue, this PR adds a script that configures the `node-linker` option to `hoisted` in the `.npmrc` file and then runs `pnpm install --force` to recreate the dependencies. This ensures that dependencies are installed at the top level instead of being duplicated in nested folders.

Once Expo SDK releases a stable version that enables [the new symlink support in React Native 0.72+](https://github.com/facebook/metro/issues/1#issuecomment-1436062881), we should check whether we can revert this PR (even though duplicate dependencies are not exactly the same issue as symlinks):

- https://github.com/upleveled/system-setup/issues/28