### PR TITLE
Switch to `create-expo`

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -357,7 +357,7 @@
     cd ~
     mkdir -p projects
     cd projects
-    pnpm create expo-app expo-test --template blank
+    pnpm create expo expo-test --template blank
     cd expo-test
     echo 'node-linker=hoisted' > ./.npmrc
     pnpm install --force

--- a/macos.md
+++ b/macos.md
@@ -374,7 +374,7 @@
     cd ~
     mkdir -p projects
     cd projects
-    pnpm create expo-app expo-test --template blank
+    pnpm create expo expo-test --template blank
     cd expo-test
     echo 'node-linker=hoisted' > ./.npmrc
     pnpm install --force

--- a/windows.md
+++ b/windows.md
@@ -487,7 +487,7 @@ With those compatibility things out of the way, you're ready to start the system
     cd ~
     mkdir -p projects
     cd projects
-    pnpm create expo-app expo-test --template blank
+    pnpm create expo expo-test --template blank
     cd expo-test
     echo 'node-linker=hoisted' > ./.npmrc
     pnpm install --force


### PR DESCRIPTION
## Description 
This PR simplifies the instructions for setting up a new React Native app with Expo. We have updated the command to `pnpm create expo` as it is more likely to be supported in the future. The change is based on [a tweet from Evan Bacon](https://twitter.com/Baconbrix/status/1652372955450441729). By following this updated guide, you'll be able to create a new React Native app with Expo using a more efficient and future-proof setup method.