### PR TITLE
Update `create expo` to use `@latest`

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -357,7 +357,7 @@
     cd ~
     mkdir -p projects
     cd projects
-    pnpm create expo expo-test --template blank
+    pnpm create expo@latest expo-test --template blank
     cd expo-test
     echo 'node-linker=hoisted' > ./.npmrc
     pnpm install --force

--- a/macos.md
+++ b/macos.md
@@ -374,7 +374,7 @@
     cd ~
     mkdir -p projects
     cd projects
-    pnpm create expo expo-test --template blank
+    pnpm create expo@latest expo-test --template blank
     cd expo-test
     echo 'node-linker=hoisted' > ./.npmrc
     pnpm install --force

--- a/windows.md
+++ b/windows.md
@@ -487,7 +487,7 @@ With those compatibility things out of the way, you're ready to start the system
     cd ~
     mkdir -p projects
     cd projects
-    pnpm create expo expo-test --template blank
+    pnpm create expo@latest expo-test --template blank
     cd expo-test
     echo 'node-linker=hoisted' > ./.npmrc
     pnpm install --force


### PR DESCRIPTION
This PR updates the Expo app setup command to include the latest version, by adding the `@latest` tag. With this change, we ensure that the latest version of Expo is installed when creating a new app.