### PR TITLE
Add `build-essential` metapackage to Linux setup

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -6,9 +6,9 @@
    ```bash
    curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
    sudo apt-get update
-   sudo apt-get install -y git nodejs python3
+   sudo apt-get install -y git nodejs python3 build-essential
    ```
-   This uses apt to install Git, Node.js and Python.<br><br>
+   This uses apt to install Git, Node.js, Python and Build Essential.<br><br>
 3. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
 
    ```bash

--- a/linux.md
+++ b/linux.md
@@ -8,7 +8,7 @@
    sudo apt-get update
    sudo apt-get install -y git nodejs python3 build-essential
    ```
-   This uses apt to install Git, Node.js, Python and Build Essential.<br><br>
+   This uses apt to install Git, Node.js, Python and the `build-essential` build tools.<br><br>
 3. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
 
    ```bash

--- a/linux.md
+++ b/linux.md
@@ -6,9 +6,9 @@
    ```bash
    curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
    sudo apt-get update
-   sudo apt-get install -y git nodejs python3 build-essential
+   sudo apt-get install -y build-essential git nodejs python3
    ```
-   This uses apt to install Git, Node.js, Python and the `build-essential` build tools.<br><br>
+   This uses apt to install the `build-essential` build tools, Git, Node.js and Python.<br><br>
 3. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
 
    ```bash


### PR DESCRIPTION
## Description

We encountered an issue during the installation of the `libpg-query` dependency while running the ESLint commands on a Linux Ubuntu machine. The error message indicated that `gyp ERR! stack Error: not found: make` was causing the problem. 

To resolve this issue, we have added the installation of [the `build-essential` metapackage](https://packages.ubuntu.com/kinetic/build-essential), which includes the necessary tools and dependencies like `make`, to the System Setup. This package will provide the required components for building native code and resolving the `node-gyp` error.

```
Progress: resolved 643, reused 614, downloaded 0, added 0, done
node_modules/.pnpm/libpg-query@15.0.2/node_modules/libpg-query: Running install script, failed in 1.7s
.../node_modules/libpg-query install$ node-pre-gyp install --fallback-to-build
│ node-pre-gyp info it worked if it ends with ok
│ node-pre-gyp info using node-pre-gyp@1.0.10
│ node-pre-gyp info using node@18.16.0 | linux | x64
│ node-pre-gyp info check checked for "/home/codevie/projects/next.js-ecomerce-store/node_modules/.pnpm/libpg-query@15.0.2/node_modules/libpg-query/build/Release/queryparser.node" (
│ node-pre-gyp http GET https://supabase-public-artifacts-bucket.s3.amazonaws.com/libpg-query-node/queryparser-v15.0.2-node-v108-linux-x64.tar.gz
│ node-pre-gyp ERR! install response status 404 Not Found on https://supabase-public-artifacts-bucket.s3.amazonaws.com/libpg-query-node/queryparser-v15.0.2-node-v108-linux-x64.tar.g
│ node-pre-gyp WARN Pre-built binaries not installable for libpg-query@15.0.2 and node@18.16.0 (node-v108 ABI, glibc) (falling back to source compile with node-gyp)
│ node-pre-gyp WARN Hit error response status 404 Not Found on https://supabase-public-artifacts-bucket.s3.amazonaws.com/libpg-query-node/queryparser-v15.0.2-node-v108-linux-x64.tar
│ gyp info it worked if it ends with ok
│ gyp info using node-gyp@9.3.1
│ gyp info using node@18.16.0 | linux | x64
│ gyp info ok
│ gyp info it worked if it ends with ok
│ gyp info using node-gyp@9.3.1
│ gyp info using node@18.16.0 | linux | x64
│ gyp info find Python using Python version 3.10.6 found at "/usr/bin/python3"
│ gyp info spawn /usr/bin/python3
│ gyp info spawn args [
│ gyp info spawn args   '/home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/node-gyp/gyp/gyp_main.py',
│ gyp info spawn args   'binding.gyp',
│ gyp info spawn args   '-f',
│ gyp info spawn args   'make',
│ gyp info spawn args   '-I',
│ gyp info spawn args   '/home/codevie/projects/next.js-ecomerce-store/node_modules/.pnpm/libpg-query@15.0.2/node_modules/libpg-query/build/config.gypi',
│ gyp info spawn args   '-I',
│ gyp info spawn args   '/home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/node-gyp/addon.gypi',
│ gyp info spawn args   '-I',
│ gyp info spawn args   '/home/codevie/.cache/node-gyp/18.16.0/include/node/common.gypi',
│ gyp info spawn args   '-Dlibrary=shared_library',
│ gyp info spawn args   '-Dvisibility=default',
│ gyp info spawn args   '-Dnode_root_dir=/home/codevie/.cache/node-gyp/18.16.0',
│ gyp info spawn args   '-Dnode_gyp_dir=/home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/node-gyp',
│ gyp info spawn args   '-Dnode_lib_file=/home/codevie/.cache/node-gyp/18.16.0/<(target_arch)/node.lib',
│ gyp info spawn args   '-Dmodule_root_dir=/home/codevie/projects/next.js-ecomerce-store/node_modules/.pnpm/libpg-query@15.0.2/node_modules/libpg-query',
│ gyp info spawn args   '-Dnode_engine=v8',
│ gyp info spawn args   '--depth=.',
│ gyp info spawn args   '--no-parallel',
│ gyp info spawn args   '--generator-output',
│ gyp info spawn args   'build',
│ gyp info spawn args   '-Goutput_dir=.'
│ gyp info spawn args ]
│ gyp info ok
│ gyp info it worked if it ends with ok
│ gyp info using node-gyp@9.3.1
│ gyp info using node@18.16.0 | linux | x64
│ gyp ERR! build error
│ gyp ERR! stack Error: not found: make
│ gyp ERR! stack     at getNotFoundError (/home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/which/which.js:10:17)
│ gyp ERR! stack     at /home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/which/which.js:57:18
│ gyp ERR! stack     at new Promise (<anonymous>)
│ gyp ERR! stack     at step (/home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/which/which.js:54:21)
│ gyp ERR! stack     at /home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/which/which.js:71:22
│ gyp ERR! stack     at new Promise (<anonymous>)
│ gyp ERR! stack     at subStep (/home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/which/which.js:69:33)
│ gyp ERR! stack     at /home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/which/which.js:80:22
│ gyp ERR! stack     at /home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/isexe/index.js:42:5
│ gyp ERR! stack     at /home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/isexe/mode.js:8:5
│ gyp ERR! System Linux 5.15.0-73-generic
│ gyp ERR! command "/usr/bin/node" "/home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/node-gyp/bin/node-gyp.js" "build" "--fallback-to-build" "--module=/home/codevie/p
│ gyp ERR! cwd /home/codevie/projects/next.js-ecomerce-store/node_modules/.pnpm/libpg-query@15.0.2/node_modules/libpg-query
│ gyp ERR! node -v v18.16.0
│ gyp ERR! node-gyp -v v9.3.1
│ gyp ERR! not ok
│ node-pre-gyp ERR! build error
│ node-pre-gyp ERR! stack Error: Failed to execute '/usr/bin/node /home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build
│ node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/home/codevie/projects/next.js-ecomerce-store/node_modules/.pnpm/@mapbox+node-pre-gyp@1.0.10/node_modules/@mapbox/node-pre
│ node-pre-gyp ERR! stack     at ChildProcess.emit (node:events:513:28)
│ node-pre-gyp ERR! stack     at maybeClose (node:internal/child_process:1091:16)
│ node-pre-gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:302:5)
│ node-pre-gyp ERR! System Linux 5.15.0-73-generic
│ node-pre-gyp ERR! command "/usr/bin/node" "/home/codevie/projects/next.js-ecomerce-store/node_modules/.pnpm/@mapbox+node-pre-gyp@1.0.10/node_modules/@mapbox/node-pre-gyp/bin/node-
│ node-pre-gyp ERR! cwd /home/codevie/projects/next.js-ecomerce-store/node_modules/.pnpm/libpg-query@15.0.2/node_modules/libpg-query
│ node-pre-gyp ERR! node -v v18.16.0
│ node-pre-gyp ERR! node-pre-gyp -v v1.0.10
│ node-pre-gyp ERR! not ok
│ Failed to execute '/usr/bin/node /home/codevie/.cache/node/corepack/pnpm/8.6.1/dist/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/home/codevie/projects
└─ Failed in 1.7s at /home/codevie/projects/next.js-ecomerce-store/node_modules/.pnpm/libpg-query@15.0.2/node_modules/libpg-query
 ELIFECYCLE  Command failed with exit code 1.
node:internal/errors:867
  const err = new Error(message);
              ^
Error: Command failed: pnpm add --save-dev @ts-safeql/eslint-plugin libpg-query
    at checkExecSyncError (node:child_process:885:11)
    at execSync (node:child_process:957:15)
    at file:///home/codevie/projects/next.js-ecomerce-store/node_modules/.pnpm/eslint-config-upleveled@4.5.0_@babel+eslint-parser@7.21.8_@next+eslint-plugin-next@13.4.4_@ty_dr5c2eo7vyjzupgwehps3i356a/node_modules/eslint-config-upleveled/bin/install.js:100:1
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 62391,
  stdout: null,
  stderr: null
}
Node.js v18.16.0
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command failed with exit code 1: upleveled-eslint-install
Command "upleveled-eslint-install" not found.
```