### PR TITLE
Add prettier.documentSelectors for SQL files

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -174,6 +174,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     "[jsonc]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+    "prettier.documentSelectors": ["**/*.sql"],
     "prettier.singleQuote": true,
     "prettier.trailingComma": "all",
     "eslint.runtime": "node",

--- a/linux.md
+++ b/linux.md
@@ -174,9 +174,13 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     "[jsonc]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
-    "prettier.documentSelectors": ["**/*.sql"],
     "prettier.singleQuote": true,
     "prettier.trailingComma": "all",
+    "prettier.documentSelectors": [
+      // Enable prettier-vscode to format *.sql files (eg. with prettier-plugin.sql)
+      // https://github.com/prettier/prettier-vscode/issues/3248#issuecomment-1956209714
+      "**/*.sql"
+      ],
     "eslint.runtime": "node",
     "eslint.experimental.useFlatConfig": true,
     ```

--- a/linux.md
+++ b/linux.md
@@ -180,7 +180,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
       // Enable prettier-vscode to format *.sql files (eg. with prettier-plugin.sql)
       // https://github.com/prettier/prettier-vscode/issues/3248#issuecomment-1956209714
       "**/*.sql"
-      ],
+    ],
     "eslint.runtime": "node",
     "eslint.experimental.useFlatConfig": true,
     ```

--- a/macos.md
+++ b/macos.md
@@ -163,6 +163,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
     "[jsonc]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+    "prettier.documentSelectors": ["**/*.sql"],
     "prettier.singleQuote": true,
     "prettier.trailingComma": "all",
     "eslint.runtime": "node",

--- a/macos.md
+++ b/macos.md
@@ -169,7 +169,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
       // Enable prettier-vscode to format *.sql files (eg. with prettier-plugin.sql)
       // https://github.com/prettier/prettier-vscode/issues/3248#issuecomment-1956209714
       "**/*.sql"
-      ],
+    ],
     "eslint.runtime": "node",
     "eslint.experimental.useFlatConfig": true,
     ```

--- a/macos.md
+++ b/macos.md
@@ -163,9 +163,13 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
     "[jsonc]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
-    "prettier.documentSelectors": ["**/*.sql"],
     "prettier.singleQuote": true,
     "prettier.trailingComma": "all",
+    "prettier.documentSelectors": [
+      // Enable prettier-vscode to format *.sql files (eg. with prettier-plugin.sql)
+      // https://github.com/prettier/prettier-vscode/issues/3248#issuecomment-1956209714
+      "**/*.sql"
+      ],
     "eslint.runtime": "node",
     "eslint.experimental.useFlatConfig": true,
     ```

--- a/windows.md
+++ b/windows.md
@@ -176,9 +176,13 @@ With those compatibility things out of the way, you're ready to start the system
     "[jsonc]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
-    "prettier.documentSelectors": ["**/*.sql"],
     "prettier.singleQuote": true,
     "prettier.trailingComma": "all",
+    "prettier.documentSelectors": [
+      // Enable prettier-vscode to format *.sql files (eg. with prettier-plugin.sql)
+      // https://github.com/prettier/prettier-vscode/issues/3248#issuecomment-1956209714
+      "**/*.sql"
+      ],
     "eslint.runtime": "node",
     "eslint.experimental.useFlatConfig": true,
     ```

--- a/windows.md
+++ b/windows.md
@@ -176,6 +176,7 @@ With those compatibility things out of the way, you're ready to start the system
     "[jsonc]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+    "prettier.documentSelectors": ["**/*.sql"],
     "prettier.singleQuote": true,
     "prettier.trailingComma": "all",
     "eslint.runtime": "node",

--- a/windows.md
+++ b/windows.md
@@ -182,7 +182,7 @@ With those compatibility things out of the way, you're ready to start the system
       // Enable prettier-vscode to format *.sql files (eg. with prettier-plugin.sql)
       // https://github.com/prettier/prettier-vscode/issues/3248#issuecomment-1956209714
       "**/*.sql"
-      ],
+    ],
     "eslint.runtime": "node",
     "eslint.experimental.useFlatConfig": true,
     ```


### PR DESCRIPTION
This PR adds the option for the VS Code user `settings.json` file to enable Prettier find the `.sql` files and format them using Prettier (with the `prettier-plugin-sql` plugin)