### PR TITLE
Upgrade to Visual Studio 2022

### DIFF
--- a/windows.md
+++ b/windows.md
@@ -63,8 +63,7 @@ With those compatibility things out of the way, you're ready to start the system
 8. Close PowerShell and open it again as administrator (like in step 2). Copy each line in the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.
 
    ```bash
-   choco install python visualstudio2017-workload-vctools -y
-   npm config set msvs_version 2017
+   choco install python visualstudio2022-workload-vctools -y
    ```
 
    This may take some time (possibly up to 15-20 minutes). This uses Chocolatey to install some Windows build tools to help with installing some Node.js native modules.

--- a/windows.md
+++ b/windows.md
@@ -66,7 +66,7 @@ With those compatibility things out of the way, you're ready to start the system
    choco install python visualstudio2022-workload-vctools -y
    ```
 
-   This may take some time (possibly up to 15-20 minutes). This uses Chocolatey to install some Windows build tools to help with installing some Node.js native modules.
+   This may take some time (possibly up to 15-20 minutes). This uses Chocolatey to install Python and Visual Studio build tools, which are required for installing Node.js native modules.
 
 9. <a name="vs-code-extensions"></a> Copy each line in the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.<br><br>
 


### PR DESCRIPTION
Closes #31

Upgrade the `choco` command to use `visualstudio2022-workload-vctools` instead of `visualstudio2017-workload-vctools` and removing the `npm` configuration line for setting `msvs_version to 2017`, as it is [no longer necessary](https://github.com/upleveled/system-setup/issues/31#issuecomment-1689874786) with the updated Visual Studio version.


