### PR TITLE
Add curl installation step to Linux setup

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -16,11 +16,12 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    <img src="linux-1-open-terminal.png"><br>
 2. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
    ```bash
+   sudo apt-get install -y curl
    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
    sudo apt-get update
    sudo apt-get install -y build-essential git nodejs python3
    ```
-   This uses apt to install the `build-essential` build tools, Git, Node.js and Python.<br><br>
+   This uses apt to install curl, the `build-essential` build tools, Git, Node.js and Python.<br><br>
 3. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
 
    ```bash


### PR DESCRIPTION
Closes #55 

The curl command-line tool isn't pre-installed in Linux Ubuntu. To make sure the System Setup works as intended, this PR adds a step to install curl before its usage. 