### PR TITLE
Update to `apt`, add Flatpak installation

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -476,16 +476,17 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
 2. If you need to record video of your screen with sound (with export to mp4 and gif), try out Kooha:
 
    ```bash
+   sudo apt install -y flatpak
    flatpak install flathub io.github.seadve.Kooha
    ```
 
 ## Software Upgrades
 
-Many software upgrades can be performed with `sudo snap refresh <package name>` or `sudo apt --only-upgrade install <package name>`, but some software upgrades require additional steps:
+Many software upgrades can be performed with `sudo snap refresh <package name>` or `sudo apt install <package name>`, but some software upgrades require additional steps:
 
 1. Node.js with pnpm
    ```bash
-   sudo apt --only-upgrade install nodejs
+   sudo apt install nodejs
    corepack disable
    corepack enable
    corepack prepare pnpm@latest --activate

--- a/linux.md
+++ b/linux.md
@@ -486,6 +486,7 @@ Many software upgrades can be performed with `sudo snap refresh <package name>` 
 
 1. Node.js with pnpm
    ```bash
+   sudo apt update
    sudo apt install nodejs
    corepack disable
    corepack enable

--- a/linux.md
+++ b/linux.md
@@ -16,10 +16,10 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    <img src="linux-1-open-terminal.png"><br>
 2. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
    ```bash
-   sudo apt-get install -y curl
+   sudo apt install -y curl
    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
-   sudo apt-get update
-   sudo apt-get install -y build-essential git nodejs python3
+   sudo apt update
+   sudo apt install -y build-essential git nodejs python3
    ```
    This uses apt to install curl, the `build-essential` build tools, Git, Node.js and Python.<br><br>
 3. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
@@ -481,11 +481,11 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
 
 ## Software Upgrades
 
-Many software upgrades can be performed with `sudo snap refresh <package name>` or `sudo apt-get --only-upgrade install <package name>`, but some software upgrades require additional steps:
+Many software upgrades can be performed with `sudo snap refresh <package name>` or `sudo apt --only-upgrade install <package name>`, but some software upgrades require additional steps:
 
 1. Node.js with pnpm
    ```bash
-   sudo apt-get --only-upgrade install nodejs
+   sudo apt --only-upgrade install nodejs
    corepack disable
    corepack enable
    corepack prepare pnpm@latest --activate

--- a/linux.md
+++ b/linux.md
@@ -487,7 +487,7 @@ Many software upgrades can be performed with `sudo snap refresh <package name>` 
 1. Node.js with pnpm
    ```bash
    sudo apt update
-   sudo apt install nodejs
+   sudo apt install -y nodejs
    corepack disable
    corepack enable
    corepack prepare pnpm@latest --activate

--- a/linux.md
+++ b/linux.md
@@ -482,7 +482,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
 
 ## Software Upgrades
 
-Many software upgrades can be performed with `sudo snap refresh <package name>` or `sudo apt install <package name>`, but some software upgrades require additional steps:
+Many software upgrades can be performed with `sudo snap refresh <package name>` or `sudo apt-get --only-upgrade install <package name>`, but some software upgrades require additional steps:
 
 1. Node.js with pnpm
    ```bash


### PR DESCRIPTION
Follow-up to #59

This PR replaces `apt-get` with `apt` in all installation commands. Using `apt` is the recommended approach, keeping our setup guide current. 

Additionally, adding the install command for Flatpack, because we are using it for the installation of Kooha.

