### PR TITLE
Avoid ERR_PNPM_NO_GLOBAL_BIN_DIR error 

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -27,7 +27,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    ```bash
    corepack enable
    corepack prepare pnpm@latest --activate
-   sudo pnpm setup
+   pnpm setup
    ```
 
    This uses Corepack to install `pnpm`, and configures `pnpm`'s global bin directory.<br><br>

--- a/linux.md
+++ b/linux.md
@@ -30,7 +30,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    sudo pnpm setup
    ```
 
-   This uses Corepack to install `pnpm`, and `pnpm` configures its global bin directory.<br><br>
+   This uses Corepack to install `pnpm`, and configures `pnpm`'s global bin directory.<br><br>
 
 4. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
 

--- a/linux.md
+++ b/linux.md
@@ -27,9 +27,10 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    ```bash
    corepack enable
    corepack prepare pnpm@latest --activate
+   sudo pnpm setup
    ```
 
-   This uses Corepack to install `pnpm`.<br><br>
+   This uses Corepack to install `pnpm`, and `pnpm` configures its global bin directory.<br><br>
 
 4. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
 

--- a/macos.md
+++ b/macos.md
@@ -44,8 +44,9 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
    ```bash
    corepack enable
    corepack prepare pnpm@latest --activate
+   pnpm setup
    ```
-   This uses Corepack to install `pnpm`.<br><br>
+   This uses Corepack to install `pnpm`, and `pnpm` configures its global bin directory.<br><br>
 8. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
    ```bash
    brew install --cask visual-studio-code httpie git-credential-manager

--- a/macos.md
+++ b/macos.md
@@ -46,7 +46,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
    corepack prepare pnpm@latest --activate
    pnpm setup
    ```
-   This uses Corepack to install `pnpm`, and `pnpm` configures its global bin directory.<br><br>
+   This uses Corepack to install `pnpm`, and configures `pnpm`'s global bin directory.<br><br>
 8. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
    ```bash
    brew install --cask visual-studio-code httpie git-credential-manager

--- a/windows.md
+++ b/windows.md
@@ -58,8 +58,9 @@ With those compatibility things out of the way, you're ready to start the system
    ```bash
    corepack enable
    corepack prepare pnpm@latest --activate
+   pnpm setup
    ```
-   This uses Corepack to install `pnpm`.<br><br>
+   This uses Corepack to install `pnpm`, and `pnpm` configures its global bin directory.<br><br>
 8. Close PowerShell and open it again as administrator (like in step 2). Copy each line in the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.
 
    ```bash

--- a/windows.md
+++ b/windows.md
@@ -60,7 +60,7 @@ With those compatibility things out of the way, you're ready to start the system
    corepack prepare pnpm@latest --activate
    pnpm setup
    ```
-   This uses Corepack to install `pnpm`, and `pnpm` configures its global bin directory.<br><br>
+   This uses Corepack to install `pnpm`, and configures `pnpm`'s global bin directory.<br><br>
 8. Close PowerShell and open it again as administrator (like in step 2). Copy each line in the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.
 
    ```bash


### PR DESCRIPTION
Closes #58 
Closes #42

Students have found an `ERR_PNPM_NO_GLOBAL_BIN_DIR` error while installing Preflight. This error occurs when a `pnpm` command is run before the global bin directory has been created using the `pnpm setup` command. To prevent this error, we are adding the `pnpm setup` command to the system setup guide that sets up this directory mentioned in this [Node.js/corepack issue](https://github.com/nodejs/corepack/issues/216).  

## Additional Notes

- Explicit testing on Linux/Ubuntu has not been performed in this PR
- The suggested `sudo pnpm setup` command for Linux mentioned in this [comment](https://github.com/upleveled/system-setup/issues/58#issuecomment-2023712876) is not used in the install script

## TODO
- [ ] test `pnpm setup` commands on all OSes




