### PR TITLE
Fix Linux @upleveled/preflight install command

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -114,7 +114,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
 
 14. Copy the following text, paste it in the terminal and hit return.<br><br>
     ```bash
-    sudo pnpm add --global @upleveled/preflight
+    pnpm add --global @upleveled/preflight
     ```
     This will prepare a program that we will use in the course.<br><br>
 15. <a name="vs-code-settings"></a> Next we will configure VS Code.<br><br>


### PR DESCRIPTION
Closes #58 

The installation command for `@upleveled/preflight` has been updated by removing the `sudo` prefix. With this change, we make sure that the package gets installed completely with `pnpm`. 