### PR TITLE
Remove unnecessary useFlatConfig setting

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -184,7 +184,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
       "**/*.sql"
     ],
     "eslint.runtime": "node",
-    "eslint.experimental.useFlatConfig": true,
+    "eslint.useFlatConfig": true,
     ```
     After you have pasted the settings, save the file with `File` -> `Save` in the top menu.<br><br>
     If you had any previous settings beforehand, you may notice that some text above will be underlined by a squiggly yellow line. This is a warning because we pasted some duplicate properties from the code above.<br><br>

--- a/linux.md
+++ b/linux.md
@@ -184,7 +184,6 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
       "**/*.sql"
     ],
     "eslint.runtime": "node",
-    "eslint.useFlatConfig": true,
     ```
     After you have pasted the settings, save the file with `File` -> `Save` in the top menu.<br><br>
     If you had any previous settings beforehand, you may notice that some text above will be underlined by a squiggly yellow line. This is a warning because we pasted some duplicate properties from the code above.<br><br>

--- a/macos.md
+++ b/macos.md
@@ -172,7 +172,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
       "**/*.sql"
     ],
     "eslint.runtime": "node",
-    "eslint.experimental.useFlatConfig": true,
+    "eslint.useFlatConfig": true,
     ```
     After you have pasted the settings, save the file with `File` -> `Save` in the top menu.<br><br>
     If you had any previous settings beforehand, you may notice that some text above will be underlined by a squiggly yellow line. This is a warning because we pasted some duplicate properties from the code above.<br><br>

--- a/macos.md
+++ b/macos.md
@@ -172,7 +172,6 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
       "**/*.sql"
     ],
     "eslint.runtime": "node",
-    "eslint.useFlatConfig": true,
     ```
     After you have pasted the settings, save the file with `File` -> `Save` in the top menu.<br><br>
     If you had any previous settings beforehand, you may notice that some text above will be underlined by a squiggly yellow line. This is a warning because we pasted some duplicate properties from the code above.<br><br>

--- a/windows.md
+++ b/windows.md
@@ -184,7 +184,7 @@ With those compatibility things out of the way, you're ready to start the system
       "**/*.sql"
     ],
     "eslint.runtime": "node",
-    "eslint.experimental.useFlatConfig": true,
+    "eslint.useFlatConfig": true,
     ```
 
     After you have pasted the settings, save the file with `File` -> `Save` in the top menu.<br><br>

--- a/windows.md
+++ b/windows.md
@@ -184,7 +184,6 @@ With those compatibility things out of the way, you're ready to start the system
       "**/*.sql"
     ],
     "eslint.runtime": "node",
-    "eslint.useFlatConfig": true,
     ```
 
     After you have pasted the settings, save the file with `File` -> `Save` in the top menu.<br><br>


### PR DESCRIPTION
From the VS Code ESLint extension [v3.0.5 prerelease notes](https://github.com/microsoft/vscode-eslint#version-305---pre-release):

> ## Version 3.0.5 - pre-release
>
> Support for the new ESLint flat config files has improved. The following changes have been implemented:
>
> To use flat config files it is recommended to use ESLint version 8.57.0 or above.
There is a new `eslint.useFlatConfig` setting which is honored by ESLint version 8.57.0 and above. If one of those versions is used, the extension adheres to the [ESLint Flat config rollout plan](https://eslint.org/blog/2023/10/flat-config-rollout-plans/). The setting has the same meaning as the environment variable `ESLINT_USE_FLAT_CONFIG`.
>
> The experimental settings `eslint.experimental.useFlatConfig` is deprecated and should only be used for ESLint versions >= 8.21 < 8.57.0.

The `3.0.10` non-prerelease version of the extension with the new setting has been released as of 17 June 2024:

- https://github.com/microsoft/vscode-eslint/issues/1644#issuecomment-2173587025

This was switched from `eslint.experimental.useFlatConfig` to `eslint.useFlatConfig` in other PRs elsewhere:

- https://github.com/roXtra/processhub-sdk/pull/2455

But in my testing (removing the `eslint.useFlatConfig` and `eslint.experimental.useFlatConfig` settings in `settings.json` and setting up a new Node.js project with the UpLeveled ESLint config), it appears that this config setting isn't required any more.

I've opened an issue here to clarify and request documentation about this:

- https://github.com/microsoft/vscode-eslint/issues/1879