### PR TITLE
Switch to create-expo-app + blank-typescript, remove .npmrc cmds

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -373,7 +373,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     cd ~
     mkdir -p projects
     cd projects
-    pnpm create expo@latest expo-test --template blank
+    pnpm create expo-app@latest --template blank-typescript expo-test
     cd expo-test
     echo 'node-linker=hoisted' > ./.npmrc
     pnpm install --force

--- a/linux.md
+++ b/linux.md
@@ -375,8 +375,6 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     cd projects
     pnpm create expo-app@latest --template blank-typescript expo-test
     cd expo-test
-    echo 'node-linker=hoisted' > ./.npmrc
-    pnpm install --force
     pnpm start --android
     ```
 

--- a/macos.md
+++ b/macos.md
@@ -388,8 +388,6 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
     cd projects
     pnpm create expo-app@latest --template blank-typescript expo-test
     cd expo-test
-    echo 'node-linker=hoisted' > ./.npmrc
-    pnpm install --force
     pnpm start --android
     ```
 

--- a/macos.md
+++ b/macos.md
@@ -386,7 +386,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
     cd ~
     mkdir -p projects
     cd projects
-    pnpm create expo@latest expo-test --template blank
+    pnpm create expo-app@latest --template blank-typescript expo-test
     cd expo-test
     echo 'node-linker=hoisted' > ./.npmrc
     pnpm install --force

--- a/windows.md
+++ b/windows.md
@@ -520,7 +520,7 @@ With those compatibility things out of the way, you're ready to start the system
     cd ~
     mkdir -p projects
     cd projects
-    pnpm create expo@latest expo-test --template blank
+    pnpm create expo-app@latest --template blank-typescript expo-test
     cd expo-test
     echo 'node-linker=hoisted' > ./.npmrc
     pnpm install --force

--- a/windows.md
+++ b/windows.md
@@ -522,8 +522,6 @@ With those compatibility things out of the way, you're ready to start the system
     cd projects
     pnpm create expo-app@latest --template blank-typescript expo-test
     cd expo-test
-    echo 'node-linker=hoisted' > ./.npmrc
-    pnpm install --force
     pnpm start --android
     ```
 


### PR DESCRIPTION
Switch from [`create-expo`](https://www.npmjs.com/package/create-expo) to [`create-expo-app`](https://www.npmjs.com/package/create-expo-app), because the Expo docs use this:

- https://docs.expo.dev/get-started/create-a-project/
- https://docs.expo.dev/more/create-expo/

Also switch from the [`blank`](https://github.com/expo/expo/tree/main/templates/expo-template-blank) template to [`blank-typescript`](https://github.com/expo/expo/tree/main/templates/expo-template-blank-typescript), because we teach Expo with TypeScript