### PR TITLE
Add Postgres Language Settings for Linux and Windows

### DIFF
--- a/windows.md
+++ b/windows.md
@@ -254,6 +254,7 @@ With those compatibility things out of the way, you're ready to start the system
     ```bash
     echo "export PATH=\$PATH:\"/c/Program Files/PostgreSQL/16/bin\"" >> "$USERPROFILE/.bash_profile"
     echo "export PGDATA=\"/c/Program Files/PostgreSQL/16/data\"" >> "$USERPROFILE/.bash_profile"
+    echo "export LC_ALL=en_US.UTF-8" >> "$USERPROFILE/.bash_profile"
     echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> "$USERPROFILE/.bash_profile"
     source "$USERPROFILE/.bash_profile"
     ```


### PR DESCRIPTION
Closes https://github.com/upleveled/system-setup/issues/73

Add the missing Postgres language settings for the `Windows` and `Linux` computers, as they are currently missing, and some students run into issues related to this.


# WIndows

The current setup doesn't set language
```bash
echo "export PATH=\$PATH:\"/c/Program Files/PostgreSQL/16/bin\"" >> "$USERPROFILE/.bash_profile"
echo "export PGDATA=\"/c/Program Files/PostgreSQL/16/data\"" >> "$USERPROFILE/.bash_profile"
echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> "$USERPROFILE/.bash_profile"
source "$USERPROFILE/.bash_profile"
```
![1111newnow](https://github.com/upleveled/system-setup/assets/74430629/dc74a58e-14c0-4e38-bf94-d7ed75afdc7f)

After the PR, the language is set
```bash
echo "export PATH=\$PATH:\"/c/Program Files/PostgreSQL/16/bin\"" >> "$USERPROFILE/.bash_profile"
echo "export PGDATA=\"/c/Program Files/PostgreSQL/16/data\"" >> "$USERPROFILE/.bash_profile"
echo "export LC_ALL=en_US.UTF-8" >> "$USERPROFILE/.bash_profile"
echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> "$USERPROFILE/.bash_profile"
source "$USERPROFILE/.bash_profile"
```
![11111newnew](https://github.com/upleveled/system-setup/assets/74430629/473168c3-96d5-417b-b414-71c580bb7e0a)
