### PR TITLE
Configure PostgreSQL time zone to UTC

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -201,6 +201,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     PGDATA=$(dirname "$(sudo -u postgres psql --tuples-only --pset format=unaligned --command "SHOW config_file;")")
     perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
+    perl -i -pe "s/^[#\s]*timezone\s*=.+$/timezone = 'UTC'/" "$PGDATA/postgresql.conf"
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     ```
 

--- a/linux.md
+++ b/linux.md
@@ -201,7 +201,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     PGDATA=$(dirname "$(sudo -u postgres psql --tuples-only --pset format=unaligned --command "SHOW config_file;")")
     perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
-    perl -i -pe "s/^[#\s]*timezone\s*=.+$/timezone = 'UTC'/" "$PGDATA/postgresql.conf"
+    perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     ```
 

--- a/macos.md
+++ b/macos.md
@@ -193,6 +193,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
     [[ -d /opt/homebrew/var/postgresql@16 ]] && PGDATA_TMP=/opt/homebrew/var/postgresql@16 || PGDATA_TMP=/usr/local/var/postgresql@16
     echo "\nexport PGDATA=$PGDATA_TMP\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
+    perl -i -pe "s/^[#\s]*timezone\s*=.+$/timezone = 'UTC'/" "$PGDATA/postgresql.conf"
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     ```
 

--- a/macos.md
+++ b/macos.md
@@ -193,7 +193,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
     [[ -d /opt/homebrew/var/postgresql@16 ]] && PGDATA_TMP=/opt/homebrew/var/postgresql@16 || PGDATA_TMP=/usr/local/var/postgresql@16
     echo "\nexport PGDATA=$PGDATA_TMP\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
-    perl -i -pe "s/^[#\s]*timezone\s*=.+$/timezone = 'UTC'/" "$PGDATA/postgresql.conf"
+    perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     ```
 

--- a/windows.md
+++ b/windows.md
@@ -257,6 +257,7 @@ With those compatibility things out of the way, you're ready to start the system
     echo "export PGDATA=\"/c/Program Files/PostgreSQL/16/data\"" >> "$USERPROFILE/.bash_profile"
     echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> "$USERPROFILE/.bash_profile"
     perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
+    perl -i -pe "s/^[#\s]*timezone\s*=.+$/timezone = 'UTC'/" "$PGDATA/postgresql.conf"
     perl -i -pe "s/^logging_collector = on/logging_collector = off/" "$PGDATA/postgresql.conf"
     source "$USERPROFILE/.bash_profile"
     ```

--- a/windows.md
+++ b/windows.md
@@ -257,7 +257,7 @@ With those compatibility things out of the way, you're ready to start the system
     echo "export PGDATA=\"/c/Program Files/PostgreSQL/16/data\"" >> "$USERPROFILE/.bash_profile"
     echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> "$USERPROFILE/.bash_profile"
     perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
-    perl -i -pe "s/^[#\s]*timezone\s*=.+$/timezone = 'UTC'/" "$PGDATA/postgresql.conf"
+    perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     perl -i -pe "s/^logging_collector = on/logging_collector = off/" "$PGDATA/postgresql.conf"
     source "$USERPROFILE/.bash_profile"
     ```


### PR DESCRIPTION
Time zone inconsistencies between systems (eg. development environment and production environment) can be very difficult to debug.

Instead, set PostgreSQL to use UTC time (which seems to be best practice for deployment infrastructure, from a quick search)

TODO:

- [x] @Eprince-hub: Check into Windows
  - [x] Do we need the command? Is there a `timezone = ...` line in the `postgresql.conf` file by default with the Chocolatey install?
  - [x] What does `SHOW TIMEZONE;` show?
  - [x] What is the system time zone?
- [x] @Eprince-hub: Check into macOS
  - [x] Do we need the command? Is there a `timezone = ...` line in the `postgresql.conf` file by default with the Homebrew install?
  - [x] What does `SHOW TIMEZONE;` show?
  - [x] What is the system time zone?
- [x] @Eprince-hub: Check into Linux
  - [x] Do we need the command? Is there a `timezone = ...` line  in the `postgresql.conf` fileby default with the APT install?
  - [x] What does `SHOW TIMEZONE;` show?
  - [x] What is the system time zone?

Useful commands:

```bash
# psql query to show database time zone
SHOW TIMEZONE;

# Show all lines in postgresql.conf
cat $PGDATA/postgresql.conf | grep timezone

# Show local system time zone
tzutil /g # Windows (unverified)
sudo systemsetup -gettimezone # macOS
timedatectl # Linux (unverified)
```

## PostgreSQL v14

Note: The checks above should be done anyway, because we support latest PostgreSQL (currently PostgreSQL v16)

But just for documentation / posterity:

### PostgreSQL v14 on macOS

On my local system (macOS PostgreSQL v14, via Homebrew), here's the output of `SHOW TIMEZONE;` before this config:

```
=> SHOW TIMEZONE;
   TimeZone
---------------
 Europe/Vienna
(1 row)
```

In my `/opt/homebrew/var/postgresql@14/postgresql.conf` file:

```bash
$ cat $PGDATA/postgresql.conf | grep timezone
log_timezone = 'Europe/Vienna'
timezone = 'Europe/Vienna'
#timezone_abbreviations = 'Default'     # Select the set of available time zone
                                        # share/timezonesets/.
```

My system time zone:

```bash
$ sudo systemsetup -gettimezone
Time Zone: Europe/Vienna
```

### PostgreSQL v14 on Linux (Debian)

With `psql` connecting to a remote PostgreSQL v14 on a Linux (Debian) machine

```
=> SHOW TIMEZONE;
 TimeZone 
----------
 UTC
(1 row)
```

Because PostgreSQL v14 is installed remotely on another system which I don't have access to, I cannot check the `postgresql.conf` file or local system time zone on that machine.