### PR TITLE
Reorder Perl scripts to run after shell sourcing

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -200,9 +200,9 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     sudo apt install postgresql-16
     echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     PGDATA=$(dirname "$(sudo -u postgres psql --tuples-only --pset format=unaligned --command "SHOW config_file;")")
+    source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
-    source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     ```
 
     This will install PostgreSQL and create a default user of `postgres` with no password (only authorized users can use this user).<br><br>

--- a/macos.md
+++ b/macos.md
@@ -192,9 +192,9 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
     ```bash
     [[ -d /opt/homebrew/var/postgresql@16 ]] && PGDATA_TMP=/opt/homebrew/var/postgresql@16 || PGDATA_TMP=/usr/local/var/postgresql@16
     echo "\nexport PGDATA=$PGDATA_TMP\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
+    source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
-    source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     ```
 
     We can now test whether PostgreSQL has been correctly installed by starting the database. To do this, we can run the following command:

--- a/windows.md
+++ b/windows.md
@@ -256,10 +256,10 @@ With those compatibility things out of the way, you're ready to start the system
     echo "export PATH=\$PATH:\"/c/Program Files/PostgreSQL/16/bin\"" >> "$USERPROFILE/.bash_profile"
     echo "export PGDATA=\"/c/Program Files/PostgreSQL/16/data\"" >> "$USERPROFILE/.bash_profile"
     echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> "$USERPROFILE/.bash_profile"
+    source "$USERPROFILE/.bash_profile"
     perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     perl -i -pe "s/^logging_collector = on/logging_collector = off/" "$PGDATA/postgresql.conf"
-    source "$USERPROFILE/.bash_profile"
     ```
 
     <!--


### PR DESCRIPTION
Running the Perl scripts in the current order causes an error as Perl cannot find the file path needed to the `postgresql.conf`
The shell needs to be sourced after Postgres installation and `PGDATA` setup before Perl can be run successfully. Changing the order of Perl commands in the setup guide so that students will run it when the file it need is ready

