### PR TITLE
Replace Perl Locale update with LANG env setting

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -198,7 +198,8 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
     sudo apt update
     sudo apt install postgresql-16
-    echo -e "\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
+    echo -e "\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
+    echo "export LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     PGDATA=$(dirname "$(sudo -u postgres psql --tuples-only --pset format=unaligned --command "SHOW config_file;")")
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"

--- a/linux.md
+++ b/linux.md
@@ -198,7 +198,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
     sudo apt update
     sudo apt install postgresql-16
-    echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
+    echo -e "export PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     PGDATA=$(dirname "$(sudo -u postgres psql --tuples-only --pset format=unaligned --command "SHOW config_file;")")
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"

--- a/linux.md
+++ b/linux.md
@@ -198,7 +198,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
     sudo apt update
     sudo apt install postgresql-16
-    echo -e "export PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
+    echo -e "\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     PGDATA=$(dirname "$(sudo -u postgres psql --tuples-only --pset format=unaligned --command "SHOW config_file;")")
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"

--- a/linux.md
+++ b/linux.md
@@ -201,7 +201,6 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     echo -e "export PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     PGDATA=$(dirname "$(sudo -u postgres psql --tuples-only --pset format=unaligned --command "SHOW config_file;")")
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
-    perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     ```
 

--- a/macos.md
+++ b/macos.md
@@ -191,7 +191,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 
     ```bash
     [[ -d /opt/homebrew/var/postgresql@16 ]] && PGDATA_TMP=/opt/homebrew/var/postgresql@16 || PGDATA_TMP=/usr/local/var/postgresql@16
-    echo "\nexport PGDATA=$PGDATA_TMP\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
+    echo -e "export PGDATA=$PGDATA_TMP\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     ```

--- a/macos.md
+++ b/macos.md
@@ -191,7 +191,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 
     ```bash
     [[ -d /opt/homebrew/var/postgresql@16 ]] && PGDATA_TMP=/opt/homebrew/var/postgresql@16 || PGDATA_TMP=/usr/local/var/postgresql@16
-    echo "\nexport PGDATA=$PGDATA_TMP\nexport LANG=en_US.UTF-8\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
+    echo -e "export PGDATA=$PGDATA_TMP\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     ```

--- a/macos.md
+++ b/macos.md
@@ -191,7 +191,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 
     ```bash
     [[ -d /opt/homebrew/var/postgresql@16 ]] && PGDATA_TMP=/opt/homebrew/var/postgresql@16 || PGDATA_TMP=/usr/local/var/postgresql@16
-    echo "\nexport PGDATA=$PGDATA_TMP\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
+    echo "\nexport PGDATA=$PGDATA_TMP\nexport LANG=en_US.UTF-8\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"

--- a/macos.md
+++ b/macos.md
@@ -193,7 +193,6 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
     [[ -d /opt/homebrew/var/postgresql@16 ]] && PGDATA_TMP=/opt/homebrew/var/postgresql@16 || PGDATA_TMP=/usr/local/var/postgresql@16
     echo "\nexport PGDATA=$PGDATA_TMP\nexport LANG=en_US.UTF-8\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
-    perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     ```
 

--- a/macos.md
+++ b/macos.md
@@ -191,7 +191,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 
     ```bash
     [[ -d /opt/homebrew/var/postgresql@16 ]] && PGDATA_TMP=/opt/homebrew/var/postgresql@16 || PGDATA_TMP=/usr/local/var/postgresql@16
-    echo -e "export PGDATA=$PGDATA_TMP\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
+    echo -e "\nexport PGDATA=$PGDATA_TMP\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     ```

--- a/macos.md
+++ b/macos.md
@@ -191,7 +191,9 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 
     ```bash
     [[ -d /opt/homebrew/var/postgresql@16 ]] && PGDATA_TMP=/opt/homebrew/var/postgresql@16 || PGDATA_TMP=/usr/local/var/postgresql@16
-    echo -e "\nexport PGDATA=$PGDATA_TMP\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
+    echo -e "\nexport PGDATA=$PGDATA_TMP" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
+    echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
+    echo "export LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     ```

--- a/macos.md
+++ b/macos.md
@@ -191,7 +191,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 
     ```bash
     [[ -d /opt/homebrew/var/postgresql@16 ]] && PGDATA_TMP=/opt/homebrew/var/postgresql@16 || PGDATA_TMP=/usr/local/var/postgresql@16
-    echo -e "export PGDATA=$PGDATA_TMP\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
+    echo "\nexport PGDATA=$PGDATA_TMP\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     ```

--- a/windows.md
+++ b/windows.md
@@ -660,5 +660,3 @@ Most software upgrades can be performed with `choco upgrade <package name>`, but
    corepack enable
    corepack prepare pnpm@latest --activate
    ```
-
-# test

--- a/windows.md
+++ b/windows.md
@@ -253,9 +253,10 @@ With those compatibility things out of the way, you're ready to start the system
     Now let's set an environment variable to tell PostgreSQL where to find the programs and where to put the data. Copy and run each of these lines separately in Hyper:
 
     ```bash
-    echo "export PATH=\$PATH:\"/c/Program Files/PostgreSQL/16/bin\"" >> "$USERPROFILE/.bash_profile"
+    echo -e "\nexport PATH=\$PATH:\"/c/Program Files/PostgreSQL/16/bin\"" >> "$USERPROFILE/.bash_profile"
     echo "export PGDATA=\"/c/Program Files/PostgreSQL/16/data\"" >> "$USERPROFILE/.bash_profile"
-    echo -e "\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> "$USERPROFILE/.bash_profile"
+    echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> "$USERPROFILE/.bash_profile"
+    echo "export LANG=en_US.UTF-8" >> "$USERPROFILE/.bash_profile"
     source "$USERPROFILE/.bash_profile"
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     perl -i -pe "s/^logging_collector = on/logging_collector = off/" "$PGDATA/postgresql.conf"

--- a/windows.md
+++ b/windows.md
@@ -257,7 +257,6 @@ With those compatibility things out of the way, you're ready to start the system
     echo "export PGDATA=\"/c/Program Files/PostgreSQL/16/data\"" >> "$USERPROFILE/.bash_profile"
     echo -e "export PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> "$USERPROFILE/.bash_profile"
     source "$USERPROFILE/.bash_profile"
-    perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     perl -i -pe "s/^logging_collector = on/logging_collector = off/" "$PGDATA/postgresql.conf"
     ```

--- a/windows.md
+++ b/windows.md
@@ -255,7 +255,7 @@ With those compatibility things out of the way, you're ready to start the system
     ```bash
     echo "export PATH=\$PATH:\"/c/Program Files/PostgreSQL/16/bin\"" >> "$USERPROFILE/.bash_profile"
     echo "export PGDATA=\"/c/Program Files/PostgreSQL/16/data\"" >> "$USERPROFILE/.bash_profile"
-    echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> "$USERPROFILE/.bash_profile"
+    echo -e "export PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> "$USERPROFILE/.bash_profile"
     source "$USERPROFILE/.bash_profile"
     perl -i -pe 's/^[#\s]*(lc_messages|lc_time)\s*=.+$/\1 = '\''en_US.UTF-8'\''/' "$PGDATA/postgresql.conf"
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"

--- a/windows.md
+++ b/windows.md
@@ -255,7 +255,7 @@ With those compatibility things out of the way, you're ready to start the system
     ```bash
     echo "export PATH=\$PATH:\"/c/Program Files/PostgreSQL/16/bin\"" >> "$USERPROFILE/.bash_profile"
     echo "export PGDATA=\"/c/Program Files/PostgreSQL/16/data\"" >> "$USERPROFILE/.bash_profile"
-    echo -e "export PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> "$USERPROFILE/.bash_profile"
+    echo -e "\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"\nexport LANG=en_US.UTF-8" >> "$USERPROFILE/.bash_profile"
     source "$USERPROFILE/.bash_profile"
     perl -i -pe "s/^[#\s]*(timezone|log_timezone)\s*=.+$/\1 = 'UTC'/" "$PGDATA/postgresql.conf"
     perl -i -pe "s/^logging_collector = on/logging_collector = off/" "$PGDATA/postgresql.conf"

--- a/windows.md
+++ b/windows.md
@@ -660,3 +660,5 @@ Most software upgrades can be performed with `choco upgrade <package name>`, but
    corepack enable
    corepack prepare pnpm@latest --activate
    ```
+
+# test


### PR DESCRIPTION
Closes https://github.com/upleveled/system-setup/issues/47

The solution provided in https://github.com/upleveled/system-setup/pull/80 caused a new error `postmaster became multithreaded during startup` as postgres server could not be started in macOS terminal if the `LANG` locale is not set. This was not noticed during the PR because the iTerm2 used for the testing sets the `LANG` locale automatically but the macOS terminal does not.

The `FATAL:  postmaster became multithreaded during startup` error could be caused by anything, but these are the things we know now so far

1. When the `LANG` environment variable is unset to `LANG=` or `LANG=""`, the above error will occur. When running Postgres from iTerm2, this error doesn't occur because [iTerm2 sets this `LANG` environment variable by default using the system language setting](https://iterm2.com/documentation/2.1/documentation-preferences.html#:~:text=Set%20locale%20variables,machine%27s%20language%20settings)
2. iTerm2 had an initial value of `en_GB.UTF-8`, which is my system's primary language setting for all locale 
3. This error occurs in the macOS terminal when running Postgres because the `LANG` is unset by default.
4. Setting the `LANG` in the macOS terminal fixed the issue, and Postgres could run without any problem
5. Unsetting the `LANG` in the iTerm2 terminal causes the error to also occur there
6. When `LANG` is set, other `LC_` variables use the value assigned to it
7. When `LANG` is unset, other `LC_` variables will have a default value of `C`

![Screenshot 2024-08-02 at 17 21 38](https://github.com/user-attachments/assets/6bbabd8e-733d-42cb-937d-94ced8689532)


## Values when `LANG` is unset

### locale output when running `locale`

macOS terminal
```bash
LANG=""
LC_COLLATE="C"
LC_CTYPE="UTF-8"
LC_MESSAGES="C"
LC_MONETARY="C"
LC_NUMERIC="C"
LC_TIME="C"
LC_ALL=
```

iterm2 Terminal
```bash
LANG=""
LC_COLLATE="C"
LC_CTYPE="C"
LC_MESSAGES="C"
LC_MONETARY="C"
LC_NUMERIC="C"
LC_TIME="C"
LC_ALL=
```

### env variables output when running `env`
macOS terminal
```bash
__CFBundleIdentifier=com.apple.Terminal
TMPDIR=/var/folders/0w/8ddfv3y91kqf7_qpsxwv9y2r0000gn/T/
XPC_FLAGS=0x0
TERM=xterm-256color
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.a9uJAPLv9o/Listeners
XPC_SERVICE_NAME=0
TERM_PROGRAM=Apple_Terminal
TERM_PROGRAM_VERSION=453
TERM_SESSION_ID=2558D981-7F90-452B-ADA4-8C036000F518
SHELL=/bin/zsh
HOME=/Users/upleveled
LOGNAME=upleveled
USER=upleveled
PATH=/Users/upleveled/.console-ninja/.bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/upleveled/development/flutter/bin:/Users/upleveled/Library/Android/sdk/platform-tools
SHLVL=1
PWD=/Users/upleveled
OLDPWD=/Users/upleveled/upleveled/system-setup
ANDROID_SDK=/Users/upleveled/Android/Sdk
HOMEBREW_PREFIX=/opt/homebrew
HOMEBREW_CELLAR=/opt/homebrew/Cellar
HOMEBREW_REPOSITORY=/opt/homebrew
INFOPATH=/opt/homebrew/share/info:
PGDATA=/opt/homebrew/var/postgresql@16
PSQL_PAGER=less --chop-long-lines --header 1
LC_CTYPE=UTF-8
_=/usr/bin/env
```
iterm2 terminal
```bash
TERM_SESSION_ID=w0t0p0:289876C1-77BD-4A97-92B7-FB315FED884B
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.a9uJAPLv9o/Listeners
LC_TERMINAL_VERSION=3.5.3
COLORFGBG=15;0
ITERM_PROFILE=Default
XPC_FLAGS=0x0
PWD=/Users/upleveled
SHELL=/bin/zsh
__CFBundleIdentifier=com.googlecode.iterm2
TERM_FEATURES=T3LrMSc7UUw9Ts3BFGsSyHNoSxF
TERM_PROGRAM_VERSION=3.5.3
TERM_PROGRAM=iTerm.app
PATH=/Users/upleveled/.console-ninja/.bin:/Users/upleveled/.console-ninja/.bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/upleveled/development/flutter/bin:/Users/upleveled/Library/Android/sdk/platform-tools:/Applications/iTerm.app/Contents/Resources/utilities
LC_TERMINAL=iTerm2
COLORTERM=truecolor
COMMAND_MODE=unix2003
TERM=xterm-256color
TERMINFO_DIRS=/Applications/iTerm.app/Contents/Resources/terminfo:/usr/share/terminfo
HOME=/Users/upleveled
TMPDIR=/var/folders/0w/8ddfv3y91kqf7_qpsxwv9y2r0000gn/T/
USER=upleveled
XPC_SERVICE_NAME=0
LOGNAME=upleveled
ITERM_SESSION_ID=w0t0p0:289876C1-77BD-4A97-92B7-FB315FED884B
__CF_USER_TEXT_ENCODING=0x0:0:0
SHLVL=1
OLDPWD=/Users/upleveled
ANDROID_SDK=/Users/upleveled/Android/Sdk
HOMEBREW_PREFIX=/opt/homebrew
HOMEBREW_CELLAR=/opt/homebrew/Cellar
HOMEBREW_REPOSITORY=/opt/homebrew
INFOPATH=/opt/homebrew/share/info:
PGDATA=/opt/homebrew/var/postgresql@16
PSQL_PAGER=less --chop-long-lines --header 1
_=/usr/bin/env
```

### Postgres not running when `LANG` is unset

iTerm2 terminal
<img width="999" alt="Screenshot 2024-08-02 at 18 34 39" src="https://github.com/user-attachments/assets/246773ea-ee2c-401c-a3a5-3da296943db5">

macOS terminal
<img width="807" alt="Screenshot 2024-08-02 at 18 35 24" src="https://github.com/user-attachments/assets/6b3cc79c-cbbc-47be-bf7d-831c3e8c7639">

## Values when `LANG` is set

### locale output when running `locale`

macOS terminal
```bash
LANG="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_CTYPE="UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_ALL=
```
iTerm2 Terminal
```bash
LANG="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_CTYPE="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_ALL=
```
### env variables output when running `env`

macOS terminal
```bash
__CFBundleIdentifier=com.apple.Terminal
TMPDIR=/var/folders/0w/8ddfv3y91kqf7_qpsxwv9y2r0000gn/T/
XPC_FLAGS=0x0
TERM=xterm-256color
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.a9uJAPLv9o/Listeners
XPC_SERVICE_NAME=0
TERM_PROGRAM=Apple_Terminal
TERM_PROGRAM_VERSION=453
TERM_SESSION_ID=2558D981-7F90-452B-ADA4-8C036000F518
SHELL=/bin/zsh
HOME=/Users/upleveled
LOGNAME=upleveled
USER=upleveled
PATH=/Users/upleveled/.console-ninja/.bin:/Users/upleveled/.console-ninja/.bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/upleveled/development/flutter/bin:/Users/upleveled/Library/Android/sdk/platform-tools
SHLVL=1
PWD=/Users/upleveled
OLDPWD=/Users/upleveled/upleveled/system-setup
ANDROID_SDK=/Users/upleveled/Android/Sdk
HOMEBREW_PREFIX=/opt/homebrew
HOMEBREW_CELLAR=/opt/homebrew/Cellar
HOMEBREW_REPOSITORY=/opt/homebrew
INFOPATH=/opt/homebrew/share/info:
PGDATA=/opt/homebrew/var/postgresql@16
PSQL_PAGER=less --chop-long-lines --header 1
LANG=en_US.UTF-8
LC_CTYPE=UTF-8
_=/usr/bin/env
```

iTerm2 terminal
```bash
TERM_SESSION_ID=w0t0p0:289876C1-77BD-4A97-92B7-FB315FED884B
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.a9uJAPLv9o/Listeners
LC_TERMINAL_VERSION=3.5.3
COLORFGBG=15;0
ITERM_PROFILE=Default
XPC_FLAGS=0x0
PWD=/Users/upleveled
SHELL=/bin/zsh
__CFBundleIdentifier=com.googlecode.iterm2
TERM_FEATURES=T3LrMSc7UUw9Ts3BFGsSyHNoSxF
TERM_PROGRAM_VERSION=3.5.3
TERM_PROGRAM=iTerm.app
PATH=/Users/upleveled/.console-ninja/.bin:/Users/upleveled/.console-ninja/.bin:/Users/upleveled/.console-ninja/.bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/upleveled/development/flutter/bin:/Users/upleveled/Library/Android/sdk/platform-tools:/Applications/iTerm.app/Contents/Resources/utilities
LC_TERMINAL=iTerm2
COLORTERM=truecolor
COMMAND_MODE=unix2003
TERM=xterm-256color
TERMINFO_DIRS=/Applications/iTerm.app/Contents/Resources/terminfo:/usr/share/terminfo
HOME=/Users/upleveled
TMPDIR=/var/folders/0w/8ddfv3y91kqf7_qpsxwv9y2r0000gn/T/
USER=upleveled
XPC_SERVICE_NAME=0
LOGNAME=upleveled
ITERM_SESSION_ID=w0t0p0:289876C1-77BD-4A97-92B7-FB315FED884B
__CF_USER_TEXT_ENCODING=0x0:0:0
SHLVL=1
OLDPWD=/Users/upleveled
ANDROID_SDK=/Users/upleveled/Android/Sdk
HOMEBREW_PREFIX=/opt/homebrew
HOMEBREW_CELLAR=/opt/homebrew/Cellar
HOMEBREW_REPOSITORY=/opt/homebrew
INFOPATH=/opt/homebrew/share/info:
PGDATA=/opt/homebrew/var/postgresql@16
PSQL_PAGER=less --chop-long-lines --header 1
LANG=en_US.UTF-8
_=/usr/bin/env
```

### Postgres running with no error when `LANG` is set

iTerm2
<img width="1010" alt="Screenshot 2024-08-02 at 18 30 57" src="https://github.com/user-attachments/assets/d7e3df89-0c09-46f6-a1ac-86b86ba4b1de">

macOS terminal
<img width="820" alt="Screenshot 2024-08-02 at 18 31 47" src="https://github.com/user-attachments/assets/9da7a7da-d244-48f4-9232-3747814bc062">


https://iterm2.com/documentation-preferences-profiles-terminal.html#:~:text=a%20bell%20graphic.-,Environment,-You%20have%20the


##  Solutions: setting the `LANG`
After checking all the systems, I realized that setting the `LANG` to English and recommended encoding (export LANG=en_US.UTF-8) will make Postgres use these values and encoding which will solve the postmaster multithreaded error and also make postgres ignore the values of the `lc_messages` and the lc_time` set in the `postgresql.conf` file which makes this PR https://github.com/upleveled/system-setup/pull/80 obsolete. 
[Postgres will only default to the values in postgresql.conf file if none of these are set (LC_ALL, LC_COLLATE, LANG)](https://www.postgresql.org/docs/current/locale.html#:~:text=When%20we%20speak,to%20C.)

Before running the environment variable setup

![Screenshot 2024-08-06 162316](https://github.com/user-attachments/assets/5afafa9f-d50a-4127-939a-afd59fc659df)
<img width="1913" alt="Screenshot 2024-08-06 at 16 20 15" src="https://github.com/user-attachments/assets/90743dcf-1723-480e-967b-879de8d48d34">
<img width="1127" alt="Screenshot 2024-08-06 at 16 35 27" src="https://github.com/user-attachments/assets/c343114b-3840-4d8a-bd74-cf63cb2878af">

After running the environment variable setup

![Screenshot 2024-08-06 162351](https://github.com/user-attachments/assets/b0335200-8096-47ac-a801-4c5ddcebdce7)
<img width="1913" alt="Screenshot 2024-08-06 at 16 20 37" src="https://github.com/user-attachments/assets/04e4a142-af12-4d42-a0eb-72f319d8eb25">
<img width="1127" alt="Screenshot 2024-08-06 at 16 37 32" src="https://github.com/user-attachments/assets/507ad807-a19c-4606-887c-52edc0dab5c4">


