### PR TITLE
Add Windows PowerShell execution policy workaround for pnpm setup

### DIFF
--- a/windows.md
+++ b/windows.md
@@ -58,6 +58,7 @@ With those compatibility things out of the way, you're ready to start the system
    ```bash
    corepack enable
    corepack prepare pnpm@latest --activate
+   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
    pnpm setup
    ```
    This uses Corepack to install `pnpm`, and configures `pnpm`'s global bin directory.<br><br>

--- a/windows.md
+++ b/windows.md
@@ -58,8 +58,7 @@ With those compatibility things out of the way, you're ready to start the system
    ```bash
    corepack enable
    corepack prepare pnpm@latest --activate
-   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-   pnpm setup
+   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass; pnpm setup
    ```
    This uses Corepack to install `pnpm`, and configures `pnpm`'s global bin directory.<br><br>
 8. Close PowerShell and open it again as administrator (like in step 2). Copy each line in the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.

--- a/windows.md
+++ b/windows.md
@@ -58,7 +58,8 @@ With those compatibility things out of the way, you're ready to start the system
    ```bash
    corepack enable
    corepack prepare pnpm@latest --activate
-   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass; pnpm setup
+   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+   pnpm setup
    ```
    This uses Corepack to install `pnpm`, and configures `pnpm`'s global bin directory.<br><br>
 8. Close PowerShell and open it again as administrator (like in step 2). Copy each line in the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.


### PR DESCRIPTION
- https://github.com/pnpm/pnpm/issues/8444

On Windows when running `pnpm setup`, Powershell throws an error:
```
>> pnpm setup
Preparing pnpm@latest for immediate activation...
pnpm : File C:\Program Files\nodejs\pnpm.ps1 cannot be loaded. The file C:\Program Files\nodejs\pnpm.ps1 is not
digitally signed. You cannot run this script on the current system. For more information about running scripts and
setting execution policy, see about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170.
At line:3 char:1
+ pnpm setup
+ ~~~~
    + CategoryInfo          : SecurityError: (:) [], PSSecurityException
    + FullyQualifiedErrorId : UnauthorizedAccess
```

This PR adds a workaround to the installation script to handle PowerShell's execution policy on Windows systems. I temporarily sets the execution policy to `Bypass` for the current session, allowing `pnpm.ps1` to run without requiring users to modify system-wide security settings as described in the Windows docs for [set the execution policy for the current PowerShell session](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.4#example-6-set-the-execution-policy-for-the-current-powershell-session)

