### PR TITLE
Remove Windows specific PostgreSQL section from macOS guide

### DIFF
--- a/macos.md
+++ b/macos.md
@@ -247,7 +247,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 
     The messages may be different than the messages in the image above, and may not mention that PostgreSQL is ready to accept connections:
 
-    <img src="./windows-5-postgres.jpg"><br><br>
+    <img src="./windows-5-postgres.avif"><br><br>
 
     You will need to run this every time you want to use your database.<br><br>
     When you want to stop PostgreSQL again, just stop it like any other command line program using the shortcut <kbd>control</kbd>-<kbd>C</kbd>.

--- a/macos.md
+++ b/macos.md
@@ -245,10 +245,6 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 
     <img src="./macos-5-postgres.png"><br><br>
 
-    The messages may be different than the messages in the image above, and may not mention that PostgreSQL is ready to accept connections:
-
-    <img src="./windows-5-postgres.avif"><br><br>
-
     You will need to run this every time you want to use your database.<br><br>
     When you want to stop PostgreSQL again, just stop it like any other command line program using the shortcut <kbd>control</kbd>-<kbd>C</kbd>.
 


### PR DESCRIPTION
Originally, in some cases [PostgreSQL logs didn’t appear in the terminal for Windows users](https://github.com/upleveled/system-setup/issues/81), we didn't investigate and fix this at the time. Instead, we included a new section in both the Windows and macOS guides to [demonstrate different outputs](https://github.com/upleveled/system-setup/commit/a69f0da381b3153b3cca3d33fd4d293d7ad17264) when starting PostgreSQL. 

We later decided to investigate and show the logs permanently for all students by [disabling the logging_collector on Windows](https://github.com/upleveled/system-setup/pull/87), which as a side-effect, made the screenshots mostly the same for macOS. 

Since we decided to show the logs in the terminal, this PR removes the Windows-specific PostgreSQL start command section from the macOS guide. [Students working on macOS, didn't report any issues with the PostgreSQL logs in the terminal so far](https://github.com/upleveled/system-setup/pull/87#:~:text=macOS%20students%20have%20not%20reported%20issues). 

If we receive reports that PostgreSQL logs are not showing up on macOS, we will update the guide to display the logs in the terminal. 

