### PR TITLE
Set Execution Policy with -Force to avoid confirmation prompts

### DIFF
--- a/windows.md
+++ b/windows.md
@@ -59,7 +59,7 @@ With those compatibility things out of the way, you're ready to start the system
    ```bash
    corepack enable
    corepack prepare pnpm@latest --activate
-   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
    pnpm setup
    ```
 


### PR DESCRIPTION
Ref https://github.com/upleveled/system-setup/issues/97

This PR adds a [`-Force` parameter to the Windows Set-ExecutionPolicy command](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.4#-force) to remove confirmation prompts before running `pnpm setup`.
