### PR TITLE
Force program installations on all systems

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -232,7 +232,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
     sudo apt update
-    sudo apt install --yes --reinstall postgresql-1
+    sudo apt install --yes --reinstall postgresql-16
     echo -e "\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     echo "export LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     PGDATA=$(dirname "$(sudo -u postgres psql --tuples-only --pset format=unaligned --command "SHOW config_file;")")

--- a/linux.md
+++ b/linux.md
@@ -16,10 +16,10 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    <img src="linux-1-open-terminal.png"><br>
 2. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
    ```bash
-   sudo apt install --yes --force curl
+   sudo apt install --yes --reinstall curl
    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
    sudo apt update
-   sudo apt install --yes --force build-essential git nodejs python3
+   sudo apt install --yes --reinstall build-essential git nodejs python3
    ```
    This uses apt to install curl, the `build-essential` build tools, Git, Node.js and Python.<br><br>
 3. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
@@ -232,7 +232,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
     sudo apt update
-    sudo apt install --yes --force postgresql-1
+    sudo apt install --yes --reinstall postgresql-1
     echo -e "\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     echo "export LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     PGDATA=$(dirname "$(sudo -u postgres psql --tuples-only --pset format=unaligned --command "SHOW config_file;")")
@@ -519,13 +519,13 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
 2. If you want to easily capture screenshots and draw and write on them, try Flameshot:
 
    ```bash
-   sudo snap install --yes --force flameshot
+   sudo snap install --yes --reinstall flameshot
    ```
 
 3. If you need to record video of your screen with sound (with export to mp4 and gif), try out Kooha:
 
    ```bash
-   sudo apt install --yes --force flatpak
+   sudo apt install --yes --reinstall flatpak
    flatpak install flathub io.github.seadve.Kooha
    ```
 
@@ -536,7 +536,7 @@ Many software upgrades can be performed with `sudo snap refresh <package name>` 
 1. Node.js with pnpm
    ```bash
    sudo apt update
-   sudo apt install --yes --force nodejs
+   sudo apt install --yes --reinstall nodejs
    corepack disable
    corepack enable
    corepack prepare pnpm@latest --activate

--- a/linux.md
+++ b/linux.md
@@ -16,10 +16,10 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    <img src="linux-1-open-terminal.png"><br>
 2. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
    ```bash
-   sudo apt install -y curl
+   sudo apt install --yes --force curl
    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
    sudo apt update
-   sudo apt install -y build-essential git nodejs python3
+   sudo apt install --yes --force build-essential git nodejs python3
    ```
    This uses apt to install curl, the `build-essential` build tools, Git, Node.js and Python.<br><br>
 3. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
@@ -232,7 +232,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
     sudo apt update
-    sudo apt install postgresql-16
+    sudo apt install --yes --force postgresql-1
     echo -e "\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     echo "export LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     PGDATA=$(dirname "$(sudo -u postgres psql --tuples-only --pset format=unaligned --command "SHOW config_file;")")
@@ -519,13 +519,13 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
 2. If you want to easily capture screenshots and draw and write on them, try Flameshot:
 
    ```bash
-   sudo snap install flameshot
+   sudo snap install --yes --force flameshot
    ```
 
 3. If you need to record video of your screen with sound (with export to mp4 and gif), try out Kooha:
 
    ```bash
-   sudo apt install -y flatpak
+   sudo apt install --yes --force flatpak
    flatpak install flathub io.github.seadve.Kooha
    ```
 
@@ -536,7 +536,7 @@ Many software upgrades can be performed with `sudo snap refresh <package name>` 
 1. Node.js with pnpm
    ```bash
    sudo apt update
-   sudo apt install -y nodejs
+   sudo apt install --yes --force nodejs
    corepack disable
    corepack enable
    corepack prepare pnpm@latest --activate

--- a/macos.md
+++ b/macos.md
@@ -36,7 +36,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
    <img src="./macos-4.1-homebrew-next-steps.png"><br><br>
 6. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
    ```bash
-   brew install flyctl git less node@20 python -f
+   brew install flyctl git less node@20 python --yes --force
    brew link --overwrite node@20
    ```
    This uses Homebrew to install `flyctl`, Git, Less, Node.js and Python.<br><br>

--- a/macos.md
+++ b/macos.md
@@ -100,16 +100,16 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 
 8. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
    ```bash
-   brew install --cask visual-studio-code httpie git-credential-manager -f
+   brew install --cask visual-studio-code httpie git-credential-manager --yes --force
    ```
    This uses Homebrew Cask to install Visual Studio Code, HTTPie and Git Credential Manager.<br><br>
    If you don't have Zoom installed yet, run this to install it:<br>
    ```bash
-   brew install --cask zoom -f
+   brew install --cask zoom --yes --force
    ```
    If you don't have Slack installed yet, run this to install it:<br>
    ```bash
-   brew install --cask slack -f
+   brew install --cask slack --yes --force
    ```
 9. <a name="vs-code-extensions"></a> Copy each line in the following text, paste it in the terminal and hit return.<br><br>
 
@@ -137,7 +137,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 10. We recommend installing and using Chrome so that you have the same DevTools as others.<br><br>
     If you don't have Chrome installed yet, you can install it with Homebrew. To do this, copy the following text, paste it in the terminal and hit return.<br><br>
     ```bash
-    brew install --cask google-chrome -f
+    brew install --cask google-chrome --yes --force
     ```
     This uses Homebrew to install Chrome.<br><br>
 11. Install the following Chrome Extensions:
@@ -219,7 +219,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 13. <a name="postgresql"></a>We will now install PostgreSQL. Copy each line in the following text, paste it in the terminal and hit return.
 
     ```bash
-    brew install postgresql@16 -f
+    brew install postgresql@16 --yes --force
     brew link postgresql@16
     ```
 
@@ -311,7 +311,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 14. <a name="docker"></a>We will now install Docker. Copy the following text, paste it in the terminal and hit return.
 
     ```bash
-    brew install --cask docker -f
+    brew install --cask docker --yes --force
     open /Applications/Docker.app
     ```
 
@@ -348,7 +348,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
     Copy each line in the following text, paste it in the terminal and hit return.
 
     ```bash
-    brew install --cask android-studio -f
+    brew install --cask android-studio --yes --force
     [ -d "$HOME/Library/Android/sdk" ] && ANDROID_SDK=$HOME/Library/Android/sdk || ANDROID_SDK=$HOME/Android/Sdk
     echo "export ANDROID_SDK=$ANDROID_SDK" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
     echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
@@ -505,49 +505,49 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 2. If you want to easily capture screenshots and draw and write on them, try Flameshot:
 
    ```bash
-   brew install --cask flameshot -f
+   brew install --cask flameshot --yes --force
    ```
 
 3. If you need to record mp4 videos of your screen with sound, try out [Loom](https://www.loom.com/):
 
    ```bash
-   brew install --cask loom -f
+   brew install --cask loom --yes --force
    ```
 
    An alternative without the limitations of Loom is Kap:
 
    ```bash
-   brew install --cask kap -f
+   brew install --cask kap --yes --force
    ```
 
 4. If you would like to keep a history of what you have copied to your clipboard, you can try out Yippy:
 
    ```bash
-   brew install --cask yippy -f
+   brew install --cask yippy --yes --force
    ```
 
 5. To simultaneously test your web design in multiple mobile viewports, try Responsively App:
 
    ```bash
-   brew install --cask responsively -f
+   brew install --cask responsively --yes --force
    ```
 
 6. To remove secrets, large files or other undesirable files from your Git repository, try BFG Repo-Cleaner:
 
    ```bash
-   brew install bfg -f
+   brew install bfg --yes --force
    ```
 
 7. If you're running out of space on your computer, you can use Disk Inventory X to analyze your hard drive and show a chart of which items are taking up how much space:
 
    ```bash
-   brew install --cask disk-inventory-x -f
+   brew install --cask disk-inventory-x --yes --force
    ```
 
 8. To do natural language calculations and conversions, try [Numi](https://numi.app/):
 
    ```bash
-   brew install --cask numi -f
+   brew install --cask numi --yes --force
    ```
 
 ## Software Upgrades

--- a/macos.md
+++ b/macos.md
@@ -245,10 +245,6 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 
     <img src="./macos-5-postgres.png"><br><br>
 
-    The messages may be different than the messages in the image above, and may not mention that PostgreSQL is ready to accept connections:
-
-    <img src="./windows-5-postgres.jpg"><br><br>
-
     You will need to run this every time you want to use your database.<br><br>
     When you want to stop PostgreSQL again, just stop it like any other command line program using the shortcut <kbd>control</kbd>-<kbd>C</kbd>.
 

--- a/macos.md
+++ b/macos.md
@@ -36,7 +36,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
    <img src="./macos-4.1-homebrew-next-steps.png"><br><br>
 6. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
    ```bash
-   brew install flyctl git less node@20 python
+   brew install flyctl git less node@20 python -f
    brew link --overwrite node@20
    ```
    This uses Homebrew to install `flyctl`, Git, Less, Node.js and Python.<br><br>
@@ -100,16 +100,16 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 
 8. Copy each line in the following text, paste it in the terminal and hit return.<br><br>
    ```bash
-   brew install --cask visual-studio-code httpie git-credential-manager
+   brew install --cask visual-studio-code httpie git-credential-manager -f
    ```
    This uses Homebrew Cask to install Visual Studio Code, HTTPie and Git Credential Manager.<br><br>
    If you don't have Zoom installed yet, run this to install it:<br>
    ```bash
-   brew install --cask zoom
+   brew install --cask zoom -f
    ```
    If you don't have Slack installed yet, run this to install it:<br>
    ```bash
-   brew install --cask slack
+   brew install --cask slack -f
    ```
 9. <a name="vs-code-extensions"></a> Copy each line in the following text, paste it in the terminal and hit return.<br><br>
 
@@ -137,7 +137,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 10. We recommend installing and using Chrome so that you have the same DevTools as others.<br><br>
     If you don't have Chrome installed yet, you can install it with Homebrew. To do this, copy the following text, paste it in the terminal and hit return.<br><br>
     ```bash
-    brew install --cask google-chrome
+    brew install --cask google-chrome -f
     ```
     This uses Homebrew to install Chrome.<br><br>
 11. Install the following Chrome Extensions:
@@ -219,7 +219,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 13. <a name="postgresql"></a>We will now install PostgreSQL. Copy each line in the following text, paste it in the terminal and hit return.
 
     ```bash
-    brew install postgresql@16
+    brew install postgresql@16 -f
     brew link postgresql@16
     ```
 
@@ -311,7 +311,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 14. <a name="docker"></a>We will now install Docker. Copy the following text, paste it in the terminal and hit return.
 
     ```bash
-    brew install --cask docker
+    brew install --cask docker -f
     open /Applications/Docker.app
     ```
 
@@ -348,7 +348,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
     Copy each line in the following text, paste it in the terminal and hit return.
 
     ```bash
-    brew install --cask android-studio
+    brew install --cask android-studio -f
     [ -d "$HOME/Library/Android/sdk" ] && ANDROID_SDK=$HOME/Library/Android/sdk || ANDROID_SDK=$HOME/Android/Sdk
     echo "export ANDROID_SDK=$ANDROID_SDK" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
     echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
@@ -505,49 +505,49 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 2. If you want to easily capture screenshots and draw and write on them, try Flameshot:
 
    ```bash
-   brew install --cask flameshot
+   brew install --cask flameshot -f
    ```
 
 3. If you need to record mp4 videos of your screen with sound, try out [Loom](https://www.loom.com/):
 
    ```bash
-   brew install --cask loom
+   brew install --cask loom -f
    ```
 
    An alternative without the limitations of Loom is Kap:
 
    ```bash
-   brew install --cask kap
+   brew install --cask kap -f
    ```
 
 4. If you would like to keep a history of what you have copied to your clipboard, you can try out Yippy:
 
    ```bash
-   brew install --cask yippy
+   brew install --cask yippy -f
    ```
 
 5. To simultaneously test your web design in multiple mobile viewports, try Responsively App:
 
    ```bash
-   brew install --cask responsively
+   brew install --cask responsively -f
    ```
 
 6. To remove secrets, large files or other undesirable files from your Git repository, try BFG Repo-Cleaner:
 
    ```bash
-   brew install bfg
+   brew install bfg -f
    ```
 
 7. If you're running out of space on your computer, you can use Disk Inventory X to analyze your hard drive and show a chart of which items are taking up how much space:
 
    ```bash
-   brew install --cask disk-inventory-x
+   brew install --cask disk-inventory-x -f
    ```
 
 8. To do natural language calculations and conversions, try [Numi](https://numi.app/):
 
    ```bash
-   brew install --cask numi
+   brew install --cask numi -f
    ```
 
 ## Software Upgrades

--- a/windows.md
+++ b/windows.md
@@ -31,7 +31,7 @@ With those compatibility things out of the way, you're ready to start the system
    <br>This will run Powershell as an administrator user<br><br>
 3. Copy the following text (be sure you select all of it, it's very long) and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
    ```bash
-   Set-ExecutionPolicy AllSigned -f; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+   Set-ExecutionPolicy AllSigned -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
    ```
    This will install Chocolatey, a package manager which will allow us to install and uninstall programs from the command line.
    <br>
@@ -40,7 +40,7 @@ With those compatibility things out of the way, you're ready to start the system
 5. Close PowerShell and open it again as administrator (like in step 2)<br><br>
 6. Copy the following text and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
    ```bash
-   choco install git nodejs-lts vscode hyper httpie flyctl -y -f
+   choco install git nodejs-lts vscode hyper httpie flyctl --yes --force
    ```
    This uses Chocolatey to install Git, Node.js, Visual Studio Code, Hyper, HTTPie and `flyctl`.<br><br>
    <!--
@@ -48,11 +48,11 @@ With those compatibility things out of the way, you're ready to start the system
    -->
    If you don't have Zoom installed yet, run this to install it:<br>
    ```bash
-   choco install zoom -y -f
+   choco install zoom --yes --force
    ```
    If you don't have Slack installed yet, run this to install it:<br>
    ```bash
-   choco install slack -y -f
+   choco install slack --yes --force
    ```
 7. Close PowerShell and open it again as administrator (like in step 2). Copy the following text and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
 
@@ -115,7 +115,7 @@ With those compatibility things out of the way, you're ready to start the system
 8. Copy the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.
 
    ```bash
-   choco install python visualstudio2022-workload-vctools -y -f
+   choco install python visualstudio2022-workload-vctools --yes --force
    ```
 
    This may take some time (possibly up to 15-20 minutes). This uses Chocolatey to install Python and Visual Studio build tools, which are required for installing Node.js native modules.
@@ -146,7 +146,7 @@ With those compatibility things out of the way, you're ready to start the system
 10. We recommend installing and using Chrome so that you have the same DevTools as others.<br><br>
     If you don't have Chrome installed yet, you can install it with Chocolatey. To do this, copy the following text and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
     ```bash
-    choco install googlechrome -y -f
+    choco install googlechrome --yes --force
     ```
     This uses Chocolatey to install Chrome.<br><br>
 11. Install the following Chrome Extensions:
@@ -279,7 +279,7 @@ With those compatibility things out of the way, you're ready to start the system
     Copy the following text, paste it in Hyper and hit return.
 
     ```bash
-    choco install postgresql16 --params '/Password:postgres' -f
+    choco install postgresql16 --params '/Password:postgres' --yes --force
     ```
 
     This will install PostgreSQL and create a default user of `postgres` and a password of `postgres`. Remember this password and use it any time it asks from now on.
@@ -401,9 +401,9 @@ With those compatibility things out of the way, you're ready to start the system
     2. Copy the following text and paste it into Hyper. Hit enter.
 
        ```bash
-       choco install wsl2 -y -f
-       choco install wsl-ubuntu-2004 -y -f
-       choco install docker-desktop -y -f
+       choco install wsl2 --yes --force
+       choco install wsl-ubuntu-2004 --yes --force
+       choco install docker-desktop --yes --force
        ```
 
     3. Open start menu and search for "Docker Desktop". Run it. This will set up and start Docker.<br><br>
@@ -417,9 +417,9 @@ With those compatibility things out of the way, you're ready to start the system
     3. Copy the following text and paste it into Hyper. Hit enter.
 
        ```bash
-       choco install wsl2 -y -f
-       choco install wsl-ubuntu-2004 -y -f
-       choco install docker-desktop -y -f
+       choco install wsl2 --yes --force
+       choco install wsl-ubuntu-2004 --yes --force
+       choco install docker-desktop --yes --force
        ```
 
     4. Open the start menu and search for "Ubuntu". Start it - it should ask you to create a user with a password. This will be your user to log in to your Ubuntu Linux Subsystem - note down the username and password somewhere secure to make sure you do not forget it.
@@ -483,7 +483,7 @@ With those compatibility things out of the way, you're ready to start the system
     Copy each line in the following text, paste it in Hyper and hit return.
 
     ```bash
-    choco install androidstudio -f
+    choco install androidstudio --yes --force
     echo "export PATH=$HOME/AppData/Local/Android/Sdk/platform-tools:\$PATH" >> ~/.bash_profile
     source ~/.bash_profile
     ```
@@ -644,7 +644,7 @@ With those compatibility things out of the way, you're ready to start the system
 2. If you want to easily capture screenshots and draw and write on them, try Flameshot:
 
    ```bash
-   choco install flameshot -f
+   choco install flameshot --yes --force
    ```
 
 3. If you need to record mp4 videos of your screen with sound, try out [Loom](https://www.loom.com/).
@@ -652,37 +652,37 @@ With those compatibility things out of the way, you're ready to start the system
    An alternative without the limitations of Loom is Screen to Gif (however, it does not record audio):
 
    ```bash
-   choco install screentogif -f
+   choco install screentogif --yes --force
    ```
 
 4. If you need a clipboard manager to keep a history of things that you have copied, this is an awesome option:
 
    ```bash
-   choco install ditto -f
+   choco install ditto --yes --force
    ```
 
 5. To simultaneously test your web design in multiple mobile viewports, try Responsively App:
 
    ```bash
-   choco install responsively -f
+   choco install responsively --yes --force
    ```
 
 6. To remove secrets, large files or other undesirable files from your Git repository, try BFG Repo-Cleaner:
 
    ```bash
-   choco install bfg-repo-cleaner -f
+   choco install bfg-repo-cleaner --yes --force
    ```
 
 7. If you're running out of space on your computer, you can use WinDirStat to analyze your hard drive and show a chart of which items are taking up how much space:
 
    ```bash
-   choco install windirstat -f
+   choco install windirstat --yes --force
    ```
 
 8. To add [an assortment of new features](https://www.fourth-wall.co.uk/post/powertoys-11-awesome-features-microsoft-won-t-add-to-windows) to Windows such as "pinning" a window to stay on top of all others, quickly renaming or resizing multiple files, splitting your running apps into regions of the screen and more, try Microsoft PowerToys:
 
    ```bash
-   choco install powertoys -f
+   choco install powertoys --yes --force
    ```
 
 ## Software Upgrades

--- a/windows.md
+++ b/windows.md
@@ -31,7 +31,7 @@ With those compatibility things out of the way, you're ready to start the system
    <br>This will run Powershell as an administrator user<br><br>
 3. Copy the following text (be sure you select all of it, it's very long) and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
    ```bash
-   Set-ExecutionPolicy AllSigned -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+   Set-ExecutionPolicy AllSigned -f; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
    ```
    This will install Chocolatey, a package manager which will allow us to install and uninstall programs from the command line.
    <br>
@@ -40,7 +40,7 @@ With those compatibility things out of the way, you're ready to start the system
 5. Close PowerShell and open it again as administrator (like in step 2)<br><br>
 6. Copy the following text and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
    ```bash
-   choco install git nodejs-lts vscode hyper httpie flyctl -y
+   choco install git nodejs-lts vscode hyper httpie flyctl -y -f
    ```
    This uses Chocolatey to install Git, Node.js, Visual Studio Code, Hyper, HTTPie and `flyctl`.<br><br>
    <!--
@@ -48,11 +48,11 @@ With those compatibility things out of the way, you're ready to start the system
    -->
    If you don't have Zoom installed yet, run this to install it:<br>
    ```bash
-   choco install zoom -y
+   choco install zoom -y -f
    ```
    If you don't have Slack installed yet, run this to install it:<br>
    ```bash
-   choco install slack -y
+   choco install slack -y -f
    ```
 7. Close PowerShell and open it again as administrator (like in step 2). Copy the following text and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
 
@@ -115,7 +115,7 @@ With those compatibility things out of the way, you're ready to start the system
 8. Copy the following text, right-click in the blue middle part of the PowerShell window to paste the text and hit enter.
 
    ```bash
-   choco install python visualstudio2022-workload-vctools -y
+   choco install python visualstudio2022-workload-vctools -y -f
    ```
 
    This may take some time (possibly up to 15-20 minutes). This uses Chocolatey to install Python and Visual Studio build tools, which are required for installing Node.js native modules.
@@ -146,7 +146,7 @@ With those compatibility things out of the way, you're ready to start the system
 10. We recommend installing and using Chrome so that you have the same DevTools as others.<br><br>
     If you don't have Chrome installed yet, you can install it with Chocolatey. To do this, copy the following text and right-click in the blue middle part of the PowerShell window to paste the text. Hit enter.<br><br>
     ```bash
-    choco install googlechrome -y
+    choco install googlechrome -y -f
     ```
     This uses Chocolatey to install Chrome.<br><br>
 11. Install the following Chrome Extensions:
@@ -279,7 +279,7 @@ With those compatibility things out of the way, you're ready to start the system
     Copy the following text, paste it in Hyper and hit return.
 
     ```bash
-    choco install postgresql16 --params '/Password:postgres'
+    choco install postgresql16 --params '/Password:postgres' -f
     ```
 
     This will install PostgreSQL and create a default user of `postgres` and a password of `postgres`. Remember this password and use it any time it asks from now on.
@@ -401,9 +401,9 @@ With those compatibility things out of the way, you're ready to start the system
     2. Copy the following text and paste it into Hyper. Hit enter.
 
        ```bash
-       choco install wsl2 -y
-       choco install wsl-ubuntu-2004 -y
-       choco install docker-desktop -y
+       choco install wsl2 -y -f
+       choco install wsl-ubuntu-2004 -y -f
+       choco install docker-desktop -y -f
        ```
 
     3. Open start menu and search for "Docker Desktop". Run it. This will set up and start Docker.<br><br>
@@ -417,9 +417,9 @@ With those compatibility things out of the way, you're ready to start the system
     3. Copy the following text and paste it into Hyper. Hit enter.
 
        ```bash
-       choco install wsl2 -y
-       choco install wsl-ubuntu-2004 -y
-       choco install docker-desktop -y
+       choco install wsl2 -y -f
+       choco install wsl-ubuntu-2004 -y -f
+       choco install docker-desktop -y -f
        ```
 
     4. Open the start menu and search for "Ubuntu". Start it - it should ask you to create a user with a password. This will be your user to log in to your Ubuntu Linux Subsystem - note down the username and password somewhere secure to make sure you do not forget it.
@@ -483,7 +483,7 @@ With those compatibility things out of the way, you're ready to start the system
     Copy each line in the following text, paste it in Hyper and hit return.
 
     ```bash
-    choco install androidstudio
+    choco install androidstudio -f
     echo "export PATH=$HOME/AppData/Local/Android/Sdk/platform-tools:\$PATH" >> ~/.bash_profile
     source ~/.bash_profile
     ```
@@ -644,7 +644,7 @@ With those compatibility things out of the way, you're ready to start the system
 2. If you want to easily capture screenshots and draw and write on them, try Flameshot:
 
    ```bash
-   choco install flameshot
+   choco install flameshot -f
    ```
 
 3. If you need to record mp4 videos of your screen with sound, try out [Loom](https://www.loom.com/).
@@ -652,37 +652,37 @@ With those compatibility things out of the way, you're ready to start the system
    An alternative without the limitations of Loom is Screen to Gif (however, it does not record audio):
 
    ```bash
-   choco install screentogif
+   choco install screentogif -f
    ```
 
 4. If you need a clipboard manager to keep a history of things that you have copied, this is an awesome option:
 
    ```bash
-   choco install ditto
+   choco install ditto -f
    ```
 
 5. To simultaneously test your web design in multiple mobile viewports, try Responsively App:
 
    ```bash
-   choco install responsively
+   choco install responsively -f
    ```
 
 6. To remove secrets, large files or other undesirable files from your Git repository, try BFG Repo-Cleaner:
 
    ```bash
-   choco install bfg-repo-cleaner
+   choco install bfg-repo-cleaner -f
    ```
 
 7. If you're running out of space on your computer, you can use WinDirStat to analyze your hard drive and show a chart of which items are taking up how much space:
 
    ```bash
-   choco install windirstat
+   choco install windirstat -f
    ```
 
 8. To add [an assortment of new features](https://www.fourth-wall.co.uk/post/powertoys-11-awesome-features-microsoft-won-t-add-to-windows) to Windows such as "pinning" a window to stay on top of all others, quickly renaming or resizing multiple files, splitting your running apps into regions of the screen and more, try Microsoft PowerToys:
 
    ```bash
-   choco install powertoys
+   choco install powertoys -f
    ```
 
 ## Software Upgrades


### PR DESCRIPTION
Make the installation commands for all systems use the `--force` flag to override any previous installations the student may have before starting the system setup

Using the `--yes --force` to prevent an already installed program/software from interfering with the new installations from the system setup on `Windows` and `macOS`

[Chocolatey Flags](https://docs.chocolatey.org/en-us/choco/commands/#default-options-and-switches)
[Homebrew Flags](https://docs.brew.sh/Manpage)

The `--reinstall` is used for the `apt` in Linux installation guide as it functions the same as `--force` used for other systems for `apt`. The `--force` flag doesn't exist for `apt`
[apt flags](https://manpages.ubuntu.com/manpages/noble/man8/apt-get.8.html)
