### PR TITLE
Upgrade PostgreSQL from v16 to v17

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -234,7 +234,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
     sudo apt update
-    sudo apt install --yes postgresql-16
+    sudo apt install --yes postgresql-17
     echo -e "\nexport PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     echo "export LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bashrc'`
     PGDATA=$(dirname "$(sudo -u postgres psql --tuples-only --pset format=unaligned --command "SHOW config_file;")")

--- a/macos.md
+++ b/macos.md
@@ -221,15 +221,15 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 13. <a name="postgresql"></a>We will now install PostgreSQL. Copy each line in the following text, paste it in the terminal and hit return.
 
     ```bash
-    brew install postgresql@16
-    brew link postgresql@16
+    brew install postgresql@17
+    brew link postgresql@17
     ```
 
     This uses Homebrew to install PostgreSQL and create just a single user with your username and all role permissions. There will be no `postgres` user set up.<br><br>
     Now let's set an environment variable to tell PostgreSQL where to put the data:
 
     ```bash
-    [[ -d /opt/homebrew/var/postgresql@16 ]] && PGDATA_TMP=/opt/homebrew/var/postgresql@16 || PGDATA_TMP=/usr/local/var/postgresql@16
+    [[ -d /opt/homebrew/var/postgresql@17 ]] && PGDATA_TMP=/opt/homebrew/var/postgresql@17 || PGDATA_TMP=/usr/local/var/postgresql@17
     echo -e "\nexport PGDATA=$PGDATA_TMP" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
     echo "export LANG=en_US.UTF-8" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`

--- a/windows.md
+++ b/windows.md
@@ -281,7 +281,7 @@ With those compatibility things out of the way, you're ready to start the system
     Copy the following text, paste it in Hyper and hit return.
 
     ```bash
-    choco install postgresql16 --yes --params '/Password:postgres'
+    choco install postgresql17 --yes --params '/Password:postgres'
     ```
 
     This will install PostgreSQL and create a default user of `postgres` and a password of `postgres`. Remember this password and use it any time it asks from now on.
@@ -291,8 +291,8 @@ With those compatibility things out of the way, you're ready to start the system
     Now let's set an environment variable to tell PostgreSQL where to find the programs and where to put the data. Copy and run each of these lines separately in Hyper:
 
     ```bash
-    echo -e "\nexport PATH=\$PATH:\"/c/Program Files/PostgreSQL/16/bin\"" >> ~/.bash_profile
-    echo "export PGDATA=\"/c/Program Files/PostgreSQL/16/data\"" >> ~/.bash_profile
+    echo -e "\nexport PATH=\$PATH:\"/c/Program Files/PostgreSQL/17/bin\"" >> ~/.bash_profile
+    echo "export PGDATA=\"/c/Program Files/PostgreSQL/17/data\"" >> ~/.bash_profile
     echo "export PSQL_PAGER=\"less --chop-long-lines --header 1\"" >> ~/.bash_profile
     echo "export LANG=en_US.UTF-8" >> ~/.bash_profile
     source ~/.bash_profile
@@ -312,11 +312,11 @@ With those compatibility things out of the way, you're ready to start the system
     cat "$USERPROFILE/.bash_profile"
     ```
 
-    It should print out something that looks like the following (although the `16` number may be different for you):
+    It should print out something that looks like the following (although the `17` number may be different for you):
 
     ```bash
-    export PATH=$PATH:"/c/Program Files/PostgreSQL/16/bin"
-    export PGDATA="/c/Program Files/PostgreSQL/16/data"
+    export PATH=$PATH:"/c/Program Files/PostgreSQL/17/bin"
+    export PGDATA="/c/Program Files/PostgreSQL/17/data"
     ```
 
     -->


### PR DESCRIPTION
- [x] Test PostgreSQL v17 on Windows
- [x] Test PostgreSQL v17 on macOS
- [x] Test PostgreSQL v17 on Linux
- [x] Check if any breaking changes with Next.js example repo
  - [x] If breaking changes: Consider impact on Curriculum Versions and need for any communication / processes

The list of breaking changes that ChatGPT came up with doesn't seem risky for our example usages:

---

PostgreSQL 17, released on September 26, 2024, introduces several changes that may affect compatibility with previous versions. Notable breaking changes include:

1. **Safe `search_path` During Maintenance Operations**:
   - Maintenance commands such as `ANALYZE`, `CLUSTER`, `CREATE INDEX`, `CREATE MATERIALIZED VIEW`, `REFRESH MATERIALIZED VIEW`, `REINDEX`, and `VACUUM` now execute functions using a safe `search_path`. Functions that reference non-default schemas must explicitly set their `search_path` during creation to ensure correct operation. 

2. **Interval Value Restrictions**:
   - The `ago` unit is now restricted to appear only at the end of interval values. Additionally, empty interval units are prevented from appearing multiple times, enforcing stricter interval formatting. 

3. **Removal of `old_snapshot_threshold` Parameter**:
   - The server configuration parameter `old_snapshot_threshold`, which allowed vacuum to remove rows potentially visible to running transactions (leading to "snapshot too old" errors), has been removed. This feature may be reintroduced in the future with an improved implementation. 

4. **Changes to `SET SESSION AUTHORIZATION` Handling**:
   - The behavior of `SET SESSION AUTHORIZATION` now depends on the session user's superuser status at the time the command is issued, rather than at connection time. This change affects how session authorization is managed during a session. 

5. **Removal of `db_user_namespace` Feature**:
   - The `db_user_namespace` feature, which simulated per-database users and was rarely used, has been removed. This change simplifies user role management. 

6. **Deprecation of `adminpack` Extension**:
   - The `adminpack` contrib extension, previously used by the now end-of-life pgAdmin III, has been removed. Users should transition to alternative administrative tools. 

7. **Change in WAL File Name Functions**:
   - The functions `pg_walfile_name()` and `pg_walfile_name_offset()` now return the current LSN segment number when the LSN is on a file segment boundary, instead of the previous segment number. This adjustment affects functions that interact with Write-Ahead Logging. 

8. **Removal of `trace_recovery_messages` Parameter**:
   - The server variable `trace_recovery_messages` has been removed, as it is no longer needed. This change streamlines recovery message tracing. 

9. **Information Schema Changes**:
   - The column `element_types.domain_default` has been removed from the information schema. This impacts queries relying on this column for domain default information. 

10. **Renaming of Statistics Columns**:
    - In the `pg_stat_bgwriter` view, the columns `buffers_backend` and `buffers_backend_fsync` have been removed, as they were considered redundant. Additionally, in the `pg_stat_statements` view, the columns `blk_read_time` and `blk_write_time` have been renamed to `shared_blk_read_time` and `shared_blk_write_time`, respectively. These changes affect monitoring and performance analysis queries. 

For a comprehensive list of changes and detailed explanations, please refer to the official PostgreSQL 17 Release Notes. 

It's advisable to thoroughly test your applications and database environments with PostgreSQL 17 to identify and address any compatibility issues arising from these changes. 

PostgreSQL v17 on macOS
<img width="962" alt="Screenshot 2025-01-07 at 12 29 11" src="https://github.com/user-attachments/assets/491da469-6af6-4d93-8e7d-de063d655c4a" />
<img width="709" alt="Screenshot 2025-01-07 at 12 29 57" src="https://github.com/user-attachments/assets/0817d430-e8fe-47bc-b892-e382bc43f542" />

Test PostgreSQL v17 on Linux
<img width="1563" alt="Screenshot 2025-01-07 at 13 25 53" src="https://github.com/user-attachments/assets/13b6db23-5a5c-4526-a766-8b028b842bd7" />
<img width="786" alt="Screenshot 2025-01-07 at 13 32 19" src="https://github.com/user-attachments/assets/86a0874c-58e1-49be-8ff0-ef9ef709de16" />

Test PostgreSQL v17 on Windows
![Screenshot 2025-01-07 163400](https://github.com/user-attachments/assets/d705571d-9036-47bf-a48d-c96d05485dfd)
![Screenshot 2025-01-07 163334](https://github.com/user-attachments/assets/86820ead-c1e2-4515-8a0e-a3e67037f833)
![Screenshot 2025-01-07 162527](https://github.com/user-attachments/assets/a038a378-67c3-4282-8818-4ce376dfabb8)

Check if any breaking changes with Next.js example repo
The Next.js example works with the PostgreSQL 17 without any issue