### PR TITLE
Configure 7 day `minimumReleaseAge` for pnpm

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -34,7 +34,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$HOME/.config/pnpm/rc"
    ```
 
-   This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory, and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>
+   This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>
 
    Install `@upleveled/preflight`, a program we will use in the course, to verify that the previous commands were successful: copy the following text, paste it in the terminal and hit return.<br><br>
 

--- a/linux.md
+++ b/linux.md
@@ -30,8 +30,8 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    pnpm setup
    source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bashrc'`
    pnpm config set minimumReleaseAge 10080 --global
-   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$HOME/.config/pnpm/rc"
-   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$HOME/.config/pnpm/rc"
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$HOME/.config/pnpm/rc"
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$HOME/.config/pnpm/rc"
    ```
 
    This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>

--- a/linux.md
+++ b/linux.md
@@ -30,6 +30,8 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    pnpm setup
    source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bashrc'`
    pnpm config set minimumReleaseAge 10080 --global
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$HOME/.config/pnpm/rc"
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$HOME/.config/pnpm/rc"
    ```
 
    This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory, and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>

--- a/linux.md
+++ b/linux.md
@@ -29,9 +29,10 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    corepack prepare pnpm@latest --activate
    pnpm setup
    source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bashrc'`
+   pnpm config set minimumReleaseAge 10080 --global
    ```
 
-   This uses Corepack to install `pnpm`, and configures `pnpm`'s global bin directory.<br><br>
+   This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory, and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>
 
    Install `@upleveled/preflight`, a program we will use in the course, to verify that the previous commands were successful: copy the following text, paste it in the terminal and hit return.<br><br>
 

--- a/macos.md
+++ b/macos.md
@@ -48,8 +48,8 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
    pnpm setup
    source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
    pnpm config set minimumReleaseAge 10080 --global
-   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"
-   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"
    ```
 
    This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>

--- a/macos.md
+++ b/macos.md
@@ -52,7 +52,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
    perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"
    ```
 
-   This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory, and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>
+   This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>
    
    Install `@upleveled/preflight`, a program we will use in the course, to verify that the previous commands were successful: copy the following text, paste it in the terminal and hit return.<br><br>
 

--- a/macos.md
+++ b/macos.md
@@ -48,6 +48,8 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
    pnpm setup
    source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
    pnpm config set minimumReleaseAge 10080 --global
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"
    ```
 
    This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory, and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>

--- a/macos.md
+++ b/macos.md
@@ -47,9 +47,10 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
    corepack prepare pnpm@latest --activate
    pnpm setup
    source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
+   pnpm config set minimumReleaseAge 10080 --global
    ```
 
-   This uses Corepack to install `pnpm`, and configures `pnpm`'s global bin directory.<br><br>
+   This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory, and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>
    
    Install `@upleveled/preflight`, a program we will use in the course, to verify that the previous commands were successful: copy the following text, paste it in the terminal and hit return.<br><br>
 

--- a/windows.md
+++ b/windows.md
@@ -61,9 +61,10 @@ With those compatibility things out of the way, you're ready to start the system
    corepack prepare pnpm@latest --activate
    Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
    pnpm setup
+   pnpm config set minimumReleaseAge 10080 --global
    ```
 
-   This uses Corepack to install `pnpm`, and configures `pnpm`'s global bin directory.<br><br>
+   This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory, and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>
    
    Close PowerShell and open it again as administrator (like in step 2).
    

--- a/windows.md
+++ b/windows.md
@@ -62,6 +62,8 @@ With those compatibility things out of the way, you're ready to start the system
    Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
    pnpm setup
    pnpm config set minimumReleaseAge 10080 --global
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$LOCALAPPDATA/pnpm/config/rc"
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$LOCALAPPDATA/pnpm/config/rc"
    ```
 
    This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory, and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>

--- a/windows.md
+++ b/windows.md
@@ -62,8 +62,8 @@ With those compatibility things out of the way, you're ready to start the system
    Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
    pnpm setup
    pnpm config set minimumReleaseAge 10080 --global
-   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$LOCALAPPDATA/pnpm/config/rc"
-   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$LOCALAPPDATA/pnpm/config/rc"
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$LOCALAPPDATA/pnpm/config/rc"
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$LOCALAPPDATA/pnpm/config/rc"
    ```
 
    This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>

--- a/windows.md
+++ b/windows.md
@@ -66,7 +66,7 @@ With those compatibility things out of the way, you're ready to start the system
    perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled\r?$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$LOCALAPPDATA/pnpm/config/rc"
    ```
 
-   This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory, and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>
+   This uses Corepack to install `pnpm`, configures `pnpm`'s global bin directory and prevents installation of packages newer than 7 days to mitigate supply chain security risks.<br><br>
    
    Close PowerShell and open it again as administrator (like in step 2).
    


### PR DESCRIPTION
To reduce risk of student environments being affected by npm supply chain attacks such as the recent high profile [Qix package attacks](https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack) and [Nx package attacks](https://socket.dev/blog/nx-packages-compromised), configure pnpm to install package versions that are at least 7 days old.

This is also tested and documented on pnpm Tricks and the related reproduction repo:

- https://github.com/karlhorky/pnpm-tricks#configure-minimumreleaseage-and-minimumreleaseageexclude-globally
- https://github.com/karlhorky/repro-pnpm-minimumReleaseAgeExclude-global-cross-platform