### PR TITLE
Switch pnpm Bash file path from .bash_profile to .bashrc

### DIFF
--- a/macos.md
+++ b/macos.md
@@ -46,7 +46,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
    corepack enable
    corepack prepare pnpm@latest --activate
    pnpm setup
-   source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'`
+   source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bashrc'`
    pnpm config set minimumReleaseAge 10080 --global
    perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=@upleveled/*$/; $_ .= "minimum-release-age-exclude[]=@upleveled/*\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"
    perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"


### PR DESCRIPTION
New version of pnpm on macOS showed a different path today for Bash:

```bash
$ pnpm setup
Created /Users/user/.bashrc
Next configuration changes were made:
export PNPM_HOME=“/Users/user/Library/pnpm”
case “:$PATH:” in
 *“:$PNPM_HOME:“*) ;;
 *) export PATH=“$PNPM_HOME:$PATH” ;;
esac
To start using pnpm, run:
source /Users/user/.bashrc
```