### PR TITLE
Fix escaping of `@`, `/` and `*` characters in Perl regexes

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -30,7 +30,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    pnpm setup
    source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bashrc'`
    pnpm config set minimumReleaseAge 10080 --global
-   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=@upleveled/*$/; $_ .= "minimum-release-age-exclude[]=@upleveled/*\n" if eof && !$exists' "$HOME/.config/pnpm/rc"
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=\@upleveled\/\*$/; $_ .= "minimum-release-age-exclude[]=\@upleveled/*\n" if eof && !$exists' "$HOME/.config/pnpm/rc"
    perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$HOME/.config/pnpm/rc"
    perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$HOME/.config/pnpm/rc"
    ```

--- a/macos.md
+++ b/macos.md
@@ -48,7 +48,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
    pnpm setup
    source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bashrc'`
    pnpm config set minimumReleaseAge 10080 --global
-   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=@upleveled/*$/; $_ .= "minimum-release-age-exclude[]=@upleveled/*\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=\@upleveled\/\*$/; $_ .= "minimum-release-age-exclude[]=\@upleveled/*\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"
    perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"
    perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$HOME/Library/Preferences/pnpm/rc"
    ```

--- a/windows.md
+++ b/windows.md
@@ -62,7 +62,7 @@ With those compatibility things out of the way, you're ready to start the system
    Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
    pnpm setup
    pnpm config set minimumReleaseAge 10080 --global
-   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=@upleveled/*$/; $_ .= "minimum-release-age-exclude[]=@upleveled/*\n" if eof && !$exists' "$LOCALAPPDATA/pnpm/config/rc"
+   perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=\@upleveled\/\*$/; $_ .= "minimum-release-age-exclude[]=\@upleveled/*\n" if eof && !$exists' "$LOCALAPPDATA/pnpm/config/rc"
    perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=eslint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=eslint-config-upleveled\n" if eof && !$exists' "$LOCALAPPDATA/pnpm/config/rc"
    perl -i -pe '$exists ||= /^minimum-release-age-exclude\[\]=stylelint-config-upleveled$/; $_ .= "minimum-release-age-exclude[]=stylelint-config-upleveled\n" if eof && !$exists' "$LOCALAPPDATA/pnpm/config/rc"
    ```


### PR DESCRIPTION
The `@upleveled` part in the regular expression was being evaluated by Perl as an unset variable (not being printed in the pnpm config file contents)

Also, the lack of escaping on the `/` and `*` was making it not idempotent (as shown in the last line)

```ini
minimum-release-age=10080
minimum-release-age-exclude[]=/*
minimum-release-age-exclude[]=eslint-config-upleveled
minimum-release-age-exclude[]=stylelint-config-upleveled
minimum-release-age-exclude[]=/*
```

After:

```ini
minimum-release-age=10080
minimum-release-age-exclude[]=@upleveled/*
minimum-release-age-exclude[]=eslint-config-upleveled
minimum-release-age-exclude[]=stylelint-config-upleveled
```