### PR TITLE
Add OBS Studio and Cap, remove Loom and Kap and ScreenToGif

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -524,7 +524,7 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
 
 ## Optional Software
 
-1. To check the spelling of all code you write in VS Code, try out [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker). You can install on the command line with this command:
+1. To check the spelling of all code you write in VS Code, try [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker). You can install on the command line with this command:
 
    ```bash
    code --install-extension streetsidesoftware.code-spell-checker
@@ -548,7 +548,13 @@ Make sure that you're running the 2nd-newest OS version or the newest version - 
    sudo snap install flameshot
    ```
 
-5. To record video of your screen with sound (with export to mp4 and gif), try out Kooha:
+5. To record videos of your screen with sound, try [OBS Studio](https://obsproject.com) (advanced):
+
+   ```bash
+   flatpak install --assumeyes flathub com.obsproject.Studio
+   ```
+
+   A simpler alternative is [Kooha](https://flathub.org/apps/io.github.seadve.Kooha):
 
    ```bash
    flatpak install --assumeyes flathub io.github.seadve.Kooha

--- a/macos.md
+++ b/macos.md
@@ -505,7 +505,7 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
 
 ## Optional Software
 
-1. To check the spelling of all code you write in VS Code, try out [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker). You can install on the command line with this command:
+1. To check the spelling of all code you write in VS Code, try [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker). You can install on the command line with this command:
 
    ```bash
    code --install-extension streetsidesoftware.code-spell-checker
@@ -529,19 +529,21 @@ Make sure that you're running the 2nd-newest macOS version or the newest version
    brew install --cask flameshot
    ```
 
-5. To record mp4 videos of your screen with sound, try out [Loom](https://www.loom.com/):
+5. To record videos of your screen with sound, try [OBS Studio](https://obsproject.com) (advanced):
 
    ```bash
-   brew install --cask loom
+   brew install --cask obs
    ```
 
-   An alternative without the limitations of Loom is Kap:
+   A simpler alternative is [Cap](https://cap.so):
 
    ```bash
-   brew install --cask kap
+   brew install --cask cap
    ```
 
-6. To keep a history of what you have copied to your clipboard, you can try out Yippy:
+   Paid macOS alternatives to Cap are [Screen Studio](https://screen.studio) and [ScreenFlow](https://www.telestream.net/screenflow/overview.htm).
+
+6. To keep a history of what you have copied to your clipboard, you can try Yippy:
 
    ```bash
    brew install --cask yippy

--- a/windows.md
+++ b/windows.md
@@ -644,7 +644,7 @@ With those compatibility things out of the way, you're ready to start the system
 
 ## Optional Software
 
-1. To check the spelling of all code you write in VS Code, try out [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker). You can install on the command line with this command:
+1. To check the spelling of all code you write in VS Code, try [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker). You can install on the command line with this command:
 
    ```bash
    code --install-extension streetsidesoftware.code-spell-checker
@@ -668,12 +668,16 @@ With those compatibility things out of the way, you're ready to start the system
    choco install flameshot --yes
    ```
 
-5. To record mp4 videos of your screen with sound, try out [Loom](https://www.loom.com/).
-
-   An alternative without the limitations of Loom is Screen to Gif (however, it does not record audio):
+5. To record videos of your screen with sound, try [OBS Studio](https://obsproject.com) (advanced):
 
    ```bash
-   choco install screentogif --yes
+   choco install obs-studio --yes
+   ```
+
+   A simpler alternative is [Cap](https://cap.so):
+
+   ```bash
+   winget install --id CapSoftware.Cap --exact --source winget --accept-package-agreements --accept-source-agreements
    ```
 
 6. To keep a history of things you have copied, clipboard managers like Ditto are an awesome option:


### PR DESCRIPTION
Closes #48

Loom downloads require a paid plan, so the Optional Software recording recommendations need alternatives that students can install from the setup guides.

This replaces the recording recommendations:

1. Old: Loom, Kap and ScreenToGif
2. OBS Studio, Cap on macOS and Windows, and Kooha on Linux

Windows uses a one-off WinGet command for Cap because no Chocolatey package exists yet:

- https://github.com/CapSoftware/Cap/issues/1729
- https://github.com/chocolatey-community/chocolatey-package-requests/issues/1649

TODO:

- [x] Replaced macOS Loom and Kap recommendations with OBS Studio and Cap
- [x] Replaced Windows Loom and ScreenToGif recommendations with OBS Studio and Cap
- [x] Added OBS Studio as the advanced Linux option and kept Kooha as the simpler Linux alternative
